### PR TITLE
Dockerfile: add common CA certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go build ./cmd/pint
 
 FROM debian:stable
 RUN apt-get update --yes && \
-    apt-get install --no-install-recommends --yes git && \
+    apt-get install --no-install-recommends --yes git ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /src/pint /usr/local/bin/pint
 WORKDIR /code


### PR DESCRIPTION
Add common CA certs to the Dockerfile. The Debian image doesn't include
them by default:
https://github.com/debuerreotype/docker-debian-artifacts/issues/15. Most
likely a user will want to use the reporter functionality hence it
should trust some root CAs such as DigiCert and so on.