### PR TITLE
checks: series: add ignore_recordingrules option

### DIFF
--- a/cmd/pint/scan.go
+++ b/cmd/pint/scan.go
@@ -52,6 +52,8 @@ func scanFiles(cfg config.Config, fcs discovery.FileFindResults, ld discovery.Li
 
 	p := parser.NewParser()
 
+	recordingRules := []*parser.RecordingRule{}
+
 	for _, path := range summary.FileChanges.Paths() {
 		path := path
 
@@ -100,6 +102,7 @@ func scanFiles(cfg config.Config, fcs discovery.FileFindResults, ld discovery.Li
 					Str("record", rule.RecordingRule.Record.Value.Value).
 					Str("lines", output.FormatLineRangeString(rule.Lines())).
 					Msg("Found recording rule")
+				recordingRules = append(recordingRules, rule.RecordingRule)
 			} else if rule.Error.Err != nil {
 				log.Debug().
 					Str("path", path).
@@ -112,7 +115,7 @@ func scanFiles(cfg config.Config, fcs discovery.FileFindResults, ld discovery.Li
 			}
 
 			if rule.Error.Err == nil {
-				checkList := cfg.GetChecksForRule(path, rule)
+				checkList := cfg.GetChecksForRule(path, rule, &recordingRules)
 				for _, check := range checkList {
 					check := check
 					scanJobs = append(scanJobs, scanJob{path: path, rule: rule, check: check})

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -470,6 +470,7 @@ series {
 - `severity` - set custom severity for reported issues, defaults to a warning.
 - `prometheus` - list of Prometheus servers to query. All servers must be first
   defined as `prometheus` blocks in global pint config.
+- `ignore_recordingrules` - if enabled then ignores issues when a metric name has been found in a recording rule. It is useful to enable this during CI because a user might add new recording rules together with alerting rules.
 
 Example:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,7 @@ func (cfg Config) String() string {
 	return string(content)
 }
 
-func (cfg Config) GetChecksForRule(path string, r parser.Rule) []checks.RuleChecker {
+func (cfg Config) GetChecksForRule(path string, r parser.Rule, recordingRules *[]*parser.RecordingRule) []checks.RuleChecker {
 	enabled := []checks.RuleChecker{}
 
 	if isEnabled(cfg.Checks.Enabled, cfg.Checks.Disabled, checks.SyntaxCheckName, r) {
@@ -65,7 +65,7 @@ func (cfg Config) GetChecksForRule(path string, r parser.Rule) []checks.RuleChec
 		}
 	}
 	for _, rule := range cfg.Rules {
-		for _, c := range rule.resolveChecks(path, r, cfg.Checks.Enabled, cfg.Checks.Disabled, proms) {
+		for _, c := range rule.resolveChecks(path, r, cfg.Checks.Enabled, cfg.Checks.Disabled, proms, recordingRules) {
 			if r.HasComment(fmt.Sprintf("disable %s", removeRedundantSpaces(c.String()))) {
 				log.Debug().
 					Str("path", path).

--- a/internal/config/rule.go
+++ b/internal/config/rule.go
@@ -112,7 +112,7 @@ type Rule struct {
 	Reject     []RejectSettings     `hcl:"reject,block"`
 }
 
-func (rule Rule) resolveChecks(path string, r parser.Rule, enabledChecks, disabledChecks []string, proms []PrometheusConfig) []checks.RuleChecker {
+func (rule Rule) resolveChecks(path string, r parser.Rule, enabledChecks, disabledChecks []string, proms []PrometheusConfig, recordingRules *[]*parser.RecordingRule) []checks.RuleChecker {
 	enabled := []checks.RuleChecker{}
 
 	if rule.Match != nil && rule.Match.Kind != "" {
@@ -211,7 +211,7 @@ func (rule Rule) resolveChecks(path string, r parser.Rule, enabledChecks, disabl
 		severity := rule.Series.getSeverity(checks.Warning)
 		for _, prom := range proms {
 			timeout, _ := parseDuration(prom.Timeout)
-			enabled = append(enabled, checks.NewSeriesCheck(prom.Name, prom.URI, timeout, severity))
+			enabled = append(enabled, checks.NewSeriesCheck(prom.Name, prom.URI, timeout, severity, rule.Series.IgnoreRR, recordingRules))
 		}
 	}
 

--- a/internal/config/series.go
+++ b/internal/config/series.go
@@ -6,6 +6,7 @@ import (
 
 type SeriesSettings struct {
 	Severity string `hcl:"severity,optional"`
+	IgnoreRR bool   `hcl:"ignore_recordingrules,optional"`
 }
 
 func (rs SeriesSettings) validate() error {


### PR DESCRIPTION
Add a new option `ignore_recordingrules` to the series check that will
make it ignore errors when checking for the existence of metrics iff
they are part of the same pull/merge request.

This improves the series check for the CI use-case significantly because
pull/merge requests might add new recording rules together with alerting
rules, and without this option the series check will fail when they
won't be found. With this option, pint would look at the newly added
recorded rules as well.