### PR TITLE
Add comparison check

### DIFF
--- a/cmd/pint/tests/0007_alerts.txt
+++ b/cmd/pint/tests/0007_alerts.txt
@@ -4,24 +4,43 @@ cmp stderr stderr.txt
 
 -- stderr.txt --
 level=info msg="Loading configuration file" [36mpath=[0m.pint.hcl
-level=info msg="File parsed" [36mpath=[0mrules/0001.yml [36mrules=[0m3
+level=info msg="File parsed" [36mpath=[0mrules/0001.yml [36mrules=[0m5
 rules/0001.yml:1-2: url annotation is required (alerts/annotation)
-- alert: ServiceIsDown
-  expr: up == 0
+- alert: Always
+  expr: up
 
 rules/0001.yml:1-2: severity label is required (rule/label)
+- alert: Always
+  expr: up
+
+rules/0001.yml:2: alert query doesn't have any condition, it will always fire if the metric exists (alerts/count)
+  expr: up
+
+rules/0001.yml:9-10: url annotation is required (alerts/annotation)
 - alert: ServiceIsDown
   expr: up == 0
 
-rules/0001.yml:6: severity label value must match regex: ^critical|warning|info$ (rule/label)
+rules/0001.yml:9-10: severity label is required (rule/label)
+- alert: ServiceIsDown
+  expr: up == 0
+
+rules/0001.yml:14: severity label value must match regex: ^critical|warning|info$ (rule/label)
     severity: bad
 
-rules/0001.yml:8: url annotation value must match regex: ^https://wiki.example.com/page/(.+).html$ (alerts/annotation)
+rules/0001.yml:16: url annotation value must match regex: ^https://wiki.example.com/page/(.+).html$ (alerts/annotation)
     url: bad
 
-level=info msg="Problems found" [36mBug=[0m2 [36mWarning=[0m2
+level=info msg="Problems found" [36mBug=[0m4 [36mWarning=[0m3
 level=fatal msg="Fatal error" [31merror=[0m[31m"problems found"[0m
 -- rules/0001.yml --
+- alert: Always
+  expr: up
+- alert: AlwaysIgnored
+  expr: up # pint disable promql/comparison
+  labels:
+    severity: warning
+  annotations:
+    url: "https://wiki.example.com/page/ServiceIsDown.html"
 - alert: ServiceIsDown
   expr: up == 0
 - alert: ServiceIsDown
@@ -48,4 +67,5 @@ rule {
         value = "critical|warning|info"
         required = true
     }
+    comparison {}
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -403,6 +403,36 @@ rule {
 }
 ```
 
+## Comparison
+
+This check enforces use of a comparison operator in alert queries.
+Since any query result triggers an alert usual query would be something
+like `error_count > 10`, so we only get `error_count` series if the value
+is above 10. If we would remove `> 10` part query would always return `error_count`
+and so it would always trigger an alert.
+
+Syntax:
+
+```JS
+comparison {
+  severity = "bug|warning|info"
+}
+```
+
+- `severity` - set custom severity for reported issues, defaults to a bug.
+
+Example:
+
+```
+rule {
+  match {
+    kind = "alerting"
+  }
+  comparison {}
+}
+```
+
+
 ## Cost
 
 This check is used to calculate cost of a query and optionally report an issue

--- a/internal/checks/base.go
+++ b/internal/checks/base.go
@@ -9,6 +9,7 @@ import (
 var (
 	CheckNames []string = []string{
 		AlertsCheckName,
+		ComparisonCheckName,
 		AnnotationCheckName,
 		ValueCheckName,
 		ByCheckName,

--- a/internal/checks/comparison_test.go
+++ b/internal/checks/comparison_test.go
@@ -1,0 +1,50 @@
+package checks_test
+
+import (
+	"testing"
+
+	"github.com/cloudflare/pint/internal/checks"
+)
+
+func TestComparisonCheck(t *testing.T) {
+	testCases := []checkTest{
+		{
+			description: "ignores recording rules",
+			content:     "- record: foo\n  expr: up == 0\n",
+			checker:     checks.NewComparisonCheck(checks.Bug),
+		},
+		{
+			description: "ignores rules with syntax errors",
+			content:     "- alert: Foo Is Down\n  expr: sum(\n",
+			checker:     checks.NewComparisonCheck(checks.Bug),
+		},
+		{
+			description: "alert expr with > condition",
+			content:     "- alert: Foo Is Down\n  for: 10m\n  expr: up{job=\"foo\"} > 0\n",
+			checker:     checks.NewComparisonCheck(checks.Bug),
+		},
+		{
+			description: "alert expr with >= condition",
+			content:     "- alert: Foo Is Down\n  for: 10m\n  expr: up{job=\"foo\"} >= 1\n",
+			checker:     checks.NewComparisonCheck(checks.Bug)},
+		{
+			description: "alert expr with == condition",
+			content:     "- alert: Foo Is Down\n  for: 10m\n  expr: up{job=\"foo\"} == 1\n",
+			checker:     checks.NewComparisonCheck(checks.Bug)},
+		{
+			description: "alert expr without any condition",
+			content:     "- alert: Foo Is Down\n  expr: up{job=\"foo\"}\n",
+			checker:     checks.NewComparisonCheck(checks.Warning), problems: []checks.Problem{
+				{
+					Fragment: `up{job="foo"}`,
+					Lines:    []int{2},
+					Reporter: "alerts/count",
+					Text:     "alert query doesn't have any condition, it will always fire if the metric exists",
+					Severity: checks.Warning,
+				},
+			},
+		},
+	}
+
+	runTests(t, testCases)
+}

--- a/internal/config/comparison.go
+++ b/internal/config/comparison.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"github.com/cloudflare/pint/internal/checks"
+)
+
+type ComparisonSettings struct {
+	Severity string `hcl:"severity,optional"`
+}
+
+func (cs ComparisonSettings) validate() error {
+	if cs.Severity != "" {
+		if _, err := checks.ParseSeverity(cs.Severity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cs ComparisonSettings) getSeverity(fallback checks.Severity) checks.Severity {
+	if cs.Severity != "" {
+		sev, _ := checks.ParseSeverity(cs.Severity)
+		return sev
+	}
+	return fallback
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -205,6 +205,12 @@ func Load(path string) (cfg Config, err error) {
 			}
 
 		}
+
+		if rule.Comparison != nil {
+			if err = rule.Comparison.validate(); err != nil {
+				return cfg, err
+			}
+		}
 	}
 
 	return cfg, nil

--- a/internal/config/rule.go
+++ b/internal/config/rule.go
@@ -110,6 +110,7 @@ type Rule struct {
 	Alerts     *AlertsSettings      `hcl:"alerts,block"`
 	Value      *ValueSettings       `hcl:"value,block"`
 	Reject     []RejectSettings     `hcl:"reject,block"`
+	Comparison *ComparisonSettings  `hcl:"comparison,block"`
 }
 
 func (rule Rule) resolveChecks(path string, r parser.Rule, enabledChecks, disabledChecks []string, proms []PrometheusConfig) []checks.RuleChecker {
@@ -259,6 +260,11 @@ func (rule Rule) resolveChecks(path string, r parser.Rule, enabledChecks, disabl
 				enabled = append(enabled, checks.NewRejectCheck(false, true, nil, re, severity))
 			}
 		}
+	}
+
+	if rule.Comparison != nil && isEnabled(enabledChecks, disabledChecks, checks.ComparisonCheckName, r) {
+		severity := rule.Comparison.getSeverity(checks.Bug)
+		enabled = append(enabled, checks.NewComparisonCheck(severity))
 	}
 
 	return enabled


### PR DESCRIPTION
This check will warn if there's an alert rule that doesn't have any condition in it, which can cause it to always fire