### PR TITLE
OBS-851 ignore problems on unmodified lines

### DIFF
--- a/internal/reporter/bitbucket.go
+++ b/internal/reporter/bitbucket.go
@@ -92,12 +92,14 @@ func (r BitBucketReporter) Submit(summary Summary) (err error) {
 func (r BitBucketReporter) makeAnnotation(report Report, summary Summary, pb git.FileBlames) (annotations []BitBucketAnnotation) {
 	gitBlames, ok := pb[report.Path]
 	if !ok {
+		log.Debug().Str("path", report.Path).Msg("File not found in git blame")
 		return
 	}
 
 	reportLine := -1
 	for _, pl := range report.Problem.Lines {
 		commit := gitBlames.GetCommit(pl)
+		log.Debug().Str("commit", commit).Str("path", report.Path).Int("line", pl).Msg("Got commit for line")
 		if summary.FileChanges.HasCommit(commit) {
 			reportLine = pl
 		}
@@ -122,6 +124,7 @@ func (r BitBucketReporter) makeAnnotation(report Report, summary Summary, pb git
 	}
 
 	if reportLine < 0 {
+		log.Debug().Str("path", report.Path).Msg("No file line found, skipping")
 		return
 	}
 


### PR DESCRIPTION
When running in CI mode all modified files are parsed and scanned. But when reporting errors to BitBucket we only send problems from modified lines (since it doesn't accept annotations on unmodified lines). This means that we can find a BUG on unmodified line and exit with non-zero code, but send a PASS report to BB.
Fix it by ignoring problems unless they are from modified lines during scan. Scan will discard anything and not pass it further if it's not modified.