### PR TITLE
fail if config file provide but does not exist

### DIFF
--- a/cmd/pint/tests/0013_issue_49.txt
+++ b/cmd/pint/tests/0013_issue_49.txt
@@ -1,0 +1,6 @@
+pint.error --config not_existed_config.hcl lint rules
+! stdout .
+cmp stderr stderr.txt
+
+-- stderr.txt --
+level=fatal msg="Fatal error" [31merror=[0m[31m"failed to load config file \"not_existed_config.hcl\": stat not_existed_config.hcl: no such file or directory"[0m

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,7 +106,12 @@ func Load(path string) (cfg Config, err error) {
 		Rules: []Rule{},
 	}
 
-	if _, err := os.Stat(path); err == nil {
+	if _, err := os.Stat(path); err != nil {
+
+		if path != ".pint.hcl" {
+			return cfg, err
+		}
+	} else {
 		log.Info().Str("path", path).Msg("Loading configuration file")
 		err = hclsimple.DecodeFile(path, nil, &cfg)
 		if err != nil {


### PR DESCRIPTION
Hi. 
Tying to resolve #49
Fail with fatal if --config flag provide but file doesn't exist on fs  