### PR TITLE
Fix off-by-one error in line reporting

### DIFF
--- a/cmd/pint/scan.go
+++ b/cmd/pint/scan.go
@@ -27,7 +27,7 @@ func tryDecodingYamlError(e string) (int, string) {
 		if err != nil {
 			return 1, e
 		}
-		return line + 1, parts[2]
+		return line, parts[2]
 	}
 	return 1, e
 }

--- a/cmd/pint/tests/0004_fail_invalid_yaml.txt
+++ b/cmd/pint/tests/0004_fail_invalid_yaml.txt
@@ -5,8 +5,8 @@ cmp stderr stderr.txt
 -- stderr.txt --
 level=error msg="Failed to parse file content" [31merror=[0m[31m"yaml: line 4: did not find expected key"[0m [36mpath=[0mrules/bad.yaml
 level=info msg="File parsed" [36mpath=[0mrules/ok.yml [36mrules=[0m1
-rules/bad.yaml:5: did not find expected key (pint/parse)
-- xx
+rules/bad.yaml:4: did not find expected key (pint/parse)
+
 
 rules/ok.yml:2: syntax error: unclosed left bracket (promql/syntax)
   expr: sum(foo[5m)

--- a/cmd/pint/tests/0010_syntax_check.txt
+++ b/cmd/pint/tests/0010_syntax_check.txt
@@ -4,8 +4,8 @@ cmp stderr stderr.txt
 
 -- stderr.txt --
 level=error msg="Failed to parse file content" [31merror=[0m[31m"yaml: line 6: did not find expected '-' indicator"[0m [36mpath=[0mrules/1.yaml
-rules/1.yaml:7: did not find expected '-' indicator (pint/parse)
-alert: Bad
+rules/1.yaml:6: did not find expected '-' indicator (pint/parse)
+
 
 level=info msg="Problems found" [36mFatal=[0m1
 level=fatal msg="Fatal error" [31merror=[0m[31m"problems found"[0m


### PR DESCRIPTION
When a file fails to parse we try to extract line number from YAML error, there's bogus +1 there.