### PR TITLE
Fix range query cache key

### DIFF
--- a/internal/promapi/range.go
+++ b/internal/promapi/range.go
@@ -64,7 +64,7 @@ func (q rangeQuery) CacheKey() string {
 	_, _ = io.WriteString(h, "\n")
 	_, _ = io.WriteString(h, q.r.Start.Format(time.RFC3339))
 	_, _ = io.WriteString(h, "\n")
-	_, _ = io.WriteString(h, q.r.End.Format(time.RFC3339))
+	_, _ = io.WriteString(h, q.r.End.Round(q.r.Step).Format(time.RFC3339))
 	_, _ = io.WriteString(h, "\n")
 	_, _ = io.WriteString(h, output.HumanizeDuration(q.r.Step))
 	return fmt.Sprintf("%x", h.Sum(nil))


### PR DESCRIPTION
It should round the end time so we reuse results from queries close to each other.