### PR TITLE
Revert: Avoid over-allocating query respones

### DIFF
--- a/internal/promapi/range.go
+++ b/internal/promapi/range.go
@@ -358,7 +358,7 @@ func streamSampleStream(r io.Reader) (samples []model.SampleStream, err error) {
 				func() {
 					samples = append(samples, sample)
 					sample.Metric = model.Metric{}
-					sample.Values = []model.SamplePair{}
+					sample.Values = make([]model.SamplePair, 0, len(sample.Values))
 				},
 			)),
 		)),


### PR DESCRIPTION
Looks like this is actually better on average.