### PR TITLE
Fix promql/vector_matching false positive

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,15 @@
   caused by queries returing huge number of results.
   As a result pint should use up to 5x less memory.
 
+### Fixed
+
+- Fixed a false positive in [promql/vector_matching](checks/promql/vector_matching.md)
+  for rules using `on(...)`. Example:
+
+  ```
+  sum(foo) without(instance) * on(app_name) group_left() bar
+  ```
+
 ## v0.30.2
 
 ### Fixed

--- a/internal/checks/promql_fragile.go
+++ b/internal/checks/promql_fragile.go
@@ -52,6 +52,9 @@ func (c FragileCheck) Check(ctx context.Context, rule parser.Rule, entries []dis
 
 func (c FragileCheck) checkNode(node *parser.PromQLNode) (problems []exprProblem) {
 	if n := utils.HasOuterBinaryExpr(node); n != nil && n.Op != promParser.LOR && n.Op != promParser.LUNLESS {
+		if n.VectorMatching != nil && n.VectorMatching.On {
+			goto NEXT
+		}
 		if _, ok := n.LHS.(*promParser.NumberLiteral); ok {
 			goto NEXT
 		}

--- a/internal/checks/promql_fragile_test.go
+++ b/internal/checks/promql_fragile_test.go
@@ -190,6 +190,21 @@ func TestFragileCheck(t *testing.T) {
 			prometheus: noProm,
 			problems:   noProblems,
 		},
+		{
+			description: "(...) without(instance) on(app_name) is ok",
+			content: `
+- alert: foo
+  expr: |
+    quantile(0.95,
+      container_memory_working_set_bytes{app_name!="foo.service"}
+      / (container_spec_memory_limit_bytes > 0)
+    ) without(instance)
+    * on(app_name) group_left(product, team, notify) job:ownership
+`,
+			checker:    newFragileCheck,
+			prometheus: noProm,
+			problems:   noProblems,
+		},
 	}
 
 	runTests(t, testCases)


### PR DESCRIPTION
Using on() means manually selecting labels, so this is not fragile.