### PR TITLE
internal/promapi: Support environment variables in headers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,7 +189,8 @@ prometheus "$name" {
   configuration, otherwise pint checks might return unreliable results and potential
   false positives.
 - `headers` - a list of HTTP headers that will be set on all requests for this Prometheus
-  server.
+  server. The header value can include environment variables (e.g. `$ENV` or `${ENV}`);
+  litteral dollar signs need to be escaped as `$$`.
 - `timeout` - timeout to be used for API requests. Defaults to 2 minutes.
 - `concurrency` - how many concurrent requests can pint send to this Prometheus server.
   Optional, defaults to 16.
@@ -245,6 +246,13 @@ prometheus "dev" {
   timeout = "30s"
   include = [ "alerts/test/.*" ]
   exclude = [ "alerts/test/docs/.*" ]
+}
+
+prometheus "auth" {
+  uri     = "https://prometheus-auth.example.com"
+  headers = {
+    "Authorization": "Bearer $CI_JWT",
+  }
 }
 ```
 

--- a/internal/promapi/prometheus_test.go
+++ b/internal/promapi/prometheus_test.go
@@ -1,0 +1,61 @@
+package promapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusRequestHeaderExpandEnv(t *testing.T) {
+	tests := []struct {
+		header      string
+		value       string
+		environment map[string]string
+		want        string
+	}{
+		{
+			header:      "Aurhorization",
+			value:       "Bearer $CI_JWT",
+			environment: map[string]string{"CI_JWT": "8iL6E1vh5qsGpccR"},
+			want:        "Bearer 8iL6E1vh5qsGpccR",
+		},
+		{
+			header:      "Escaped",
+			value:       "This $$Dollar sign is escaped",
+			environment: map[string]string{"Dollar": "This variable shouldn't be expanded"},
+			want:        "This $Dollar sign is escaped",
+		},
+		{
+			header:      "Undefined",
+			value:       "Variable $undef is undefined",
+			environment: map[string]string{},
+			want:        "Variable  is undefined",
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		require.Equal(t, query["expected"], r.Header[query.Get("header")])
+	}))
+	defer ts.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.header, func(t *testing.T) {
+			headers := make(map[string]string)
+			headers[tt.header] = tt.value
+
+			for env, value := range tt.environment {
+				os.Setenv(env, value)
+			}
+
+			prom := NewPrometheus("test", ts.URL, headers, 10*time.Second, 1, 100)
+			prom.doRequest(context.Background(), http.MethodGet, "/", url.Values{"header": {tt.header}, "expected": {tt.want}})
+		})
+	}
+}


### PR DESCRIPTION
Prometheus header values are now expanded to replace environment variables, so if

```
export CI_JWT="8iL6E1vh5qsGpccR"
```

then

```hcl
prometheus "example" {
  uri = "https://prometheus.example.com"
  headers = {
    "Authorization": "Bearer $CI_JWT",
  }
}
```

will do requests on the Prometheus server with the HTTP header

```
Authorization: Bearer 8iL6E1vh5qsGpccR
```