### PR TITLE
promql/series: don't expose internal variable

### DIFF
--- a/cmd/pint/tests/0025_config.txt
+++ b/cmd/pint/tests/0025_config.txt
@@ -94,7 +94,6 @@ level=info msg="Loading configuration file" path=.pint.hcl
   },
   "check": [
     {
-      "LookbackStepDuration": 300000000000,
       "ignoreMetrics": [
         ".*_error",
         ".*_error_.*",


### PR DESCRIPTION
The LookbackStepDuration variable leaks when doing a `pint config`

```
// pint.hcl
check "promql/series" {
  lookbackRange = "6h"
}

$ pint -c pint.hcl config
level=info msg="Loading configuration file" path=pint.hcl
{
  ...
  "check": [
    {
      "lookbackRange": "6h",
      "LookbackStepDuration": 300000000000
    }
  ]
}
```