### PR TITLE
Mention Thanos in promql/rate check

### DIFF
--- a/docs/checks/promql/rate.md
+++ b/docs/checks/promql/rate.md
@@ -30,6 +30,10 @@ to verify that:
   See [this blog post](https://www.robustperception.io/rate-then-sum-never-sum-then-rate/)
   for details.
 
+The check uses the `/api/v1/status/config` Prometheus endpoint, if you are
+running Pint against a [Thanos](https://thanos.io) system you should [disable
+this check](#how-to-disable-it).
+
 ## Common problems
 
 ### Metadata mismatch


### PR DESCRIPTION
It took me a little while to find the reason why this check was failing when running against Thanos, and to find #260.

Mention Thanos in the check's page so it should come up in search results.