### PR TITLE
let CI infer reponame/owner from GITHUB_REPOSITORY

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1426,17 +1426,6 @@ func TestConfigErrors(t *testing.T) {
 			err: "project cannot be empty",
 		},
 		{
-			config: `repository {
-  github {
-    baseuri = ""
-    timeout = ""
-    owner   = ""
-    repo    = ""
-  }
-}`,
-			err: "repo cannot be empty",
-		},
-		{
 			config: `checks { enabled = ["foo"] }`,
 			err:    "unknown check name foo",
 		},

--- a/internal/config/repository_test.go
+++ b/internal/config/repository_test.go
@@ -110,20 +110,20 @@ func TestGitHubSettings(t *testing.T) {
 			},
 			err: errors.New(`not a valid duration string: "foo"`),
 		},
-		{
-			conf: GitHub{
-				Owner:   "bar",
-				Timeout: "5m",
-			},
-			err: errors.New("repo cannot be empty"),
-		},
-		{
-			conf: GitHub{
-				Repo:    "foo",
-				Timeout: "5m",
-			},
-			err: errors.New("owner cannot be empty"),
-		},
+		// {
+		// 	conf: GitHub{
+		// 		Owner:   "bar",
+		// 		Timeout: "5m",
+		// 	},
+		// 	err: errors.New("repo cannot be empty"),
+		// },
+		// {
+		// 	conf: GitHub{
+		// 		Repo:    "foo",
+		// 		Timeout: "5m",
+		// 	},
+		// 	err: errors.New("owner cannot be empty"),
+		// },
 		{
 			conf: GitHub{
 				Repo:    "foo",


### PR DESCRIPTION
`pint ci` will try to set owner/reponame from `GITHUB_REPOSITORY`.

However, the repository config validator errors out if owner/repo are not set.