### PR TITLE
fix: positioning of comments on unmodified lines

### DIFF
--- a/internal/reporter/github.go
+++ b/internal/reporter/github.go
@@ -289,7 +289,13 @@ func reportToGitHubComment(headCommit string, rep Report) *github.PullRequestCom
 			msgPrefix,
 			rep.Problem.Text,
 		)),
-		Line: github.Int(reportLine),
+	}
+
+	if reportLine < 0 {
+		// If we couldn't find a nearby line to attach the comment to, put it on the first line of the diff
+		c.Position = github.Int(1)
+	} else {
+		c.Line = github.Int(reportLine)
 	}
 
 	return &c


### PR DESCRIPTION
If there's a comment that needs to be added to a Github PR review, and it's on an unmodified line, and pint can't find a modified line to put the comment on, then just put the comment on the first changed line of the diff.

I've tested and verified that this is working in our environment (Github Enterprise Server 3.8).

Closes https://github.com/cloudflare/pint/issues/645