### PR TITLE
Fix incorrect example for disabling promql/aggregate

### DIFF
--- a/docs/checks/promql/aggregate.md
+++ b/docs/checks/promql/aggregate.md
@@ -123,7 +123,7 @@ Example:
 Example:
 
 ```yaml
-# pint disable promql/aggregate(instance:true)
+# pint disable promql/aggregate(instance:false)
 ```
 
 ## How to snooze it


### PR DESCRIPTION
In the definition on how to disable the promql/aggregate rule for `strip` labels, it is stated to use :false as the suffix, but then uses :true in the example with a specific label.

Update the second example to match the first, correct, one.