### PR TITLE
fix: filtering of changes introduced by merges

### DIFF
--- a/internal/git/changes.go
+++ b/internal/git/changes.go
@@ -68,7 +68,7 @@ type FileChange struct {
 }
 
 func Changes(cmd CommandRunner, cr CommitRangeResults, filter PathFilter) ([]*FileChange, error) {
-	out, err := cmd("log", "--reverse", "--no-merges", "--format=%H", "--name-status", cr.String())
+	out, err := cmd("log", "--reverse", "--no-merges", "--first-parent", "--format=%H", "--name-status", cr.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the list of modified files from git: %w", err)
 	}


### PR DESCRIPTION
## Justification

As part of our Prometheus rules repository, we enforce that a branch must be up-to-date with `main` before merging a PR. This typically results in folks merging `main` into their branch (as opposed to a rebase). However, with current `pint` behavior, that results in commits from `main` being included in the rules files that `pint` looks at since it considers them changed.

This results in extraneous evaluation of rules files unrelated to a given PR, but also HTTP 422 responses from GitHub for trying to adding comments to files that aren't changed in a PR.

## Explanation

While the '--no-merges' flag excludes merge commits themselves from being included, the commits that they introduced are still included.

This means that -- in Git workflows where people are often merging the latest changes from the main branch into theirs -- the changes from the upstream get included and evaluated, rather than just the files changed within the pull request.

By adding the '--first-parent' flag, it ensures that only commits that have a "first parent" of the current branch will be included.

So, if you merge BranchB into BranchA, and now BranchB's commits will be included when merging BranchA to main, BranchB's commits will still be included in the log.

However, when merging main to BranchA and then merging BranchA to main, the commits that already came from main will be ignored.

I hope this makes sense, but it's hard to explain anything to do with Git in a simple manner lol.