### PR TITLE
Fix nil pointer exceptions in certain broken dependency scenarios

### DIFF
--- a/internal/checks/rule_dependency.go
+++ b/internal/checks/rule_dependency.go
@@ -90,12 +90,12 @@ func (c RuleDependencyCheck) Check(_ context.Context, _ string, rule parser.Rule
 
 	var details strings.Builder
 	details.WriteString("If you remove the ")
-	details.WriteString(dep.kind)
+	details.WriteString(broken[0].kind)
 	details.WriteString(" rule generating `")
-	details.WriteString(dep.metric)
+	details.WriteString(broken[0].metric)
 	details.WriteString("`, and there is no other source of this metric, then any other rule depending on it will break.\n")
 	details.WriteString("List of found rules that are using `")
-	details.WriteString(dep.metric)
+	details.WriteString(broken[0].metric)
 	details.WriteString("`:\n\n")
 	for _, b := range broken {
 		details.WriteString("- `")


### PR DESCRIPTION
When there are one or more broken dependency problems, the final value of `dep` when evaluating all entries is the one used when preparing the problem item.

However, it is possible that after a problem is identified, subsequent entries are recording or alerting rules which either do not have any vector selectors, or none that match.

In this situation, the final value of `dep` is `nil`, which causes a crash.

This change fixes this by using the first broken dependency entry recorded for building this part of the string.