### PR TITLE
feat: Add lint cfg section handling include & exclude patterns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,25 @@ owners {
 If there's no `owners:allowed` configuration block, or if it's empty, then any
 owner name is accepted.
 
+## Lint
+
+Check rules defined as cli arguments or matching a pattern specified in the hcl config file
+
+Syntax:
+
+```js
+lint {
+  include = [ "(.*)", ... ]
+  exclude = [ "(.*)", ... ]
+}
+```
+
+- `include` - list of file patterns to check when running checks. Only files
+  matching those regexp rules will be checked.
+- `exclude` - list of file patterns to ignore when running linting.
+  This option takes precedence over `include`, so if a file path matches both
+  `include` & `exclude` patterns, it will be excluded.
+
 ## CI
 
 Configure continuous integration environments.

--- a/docs/examples/lint.hcl
+++ b/docs/examples/lint.hcl
@@ -1,0 +1,9 @@
+# This is an example config to be used when running pint as a linter
+
+lint {
+  # Check all files inside rules/alerting and rules/recording dirs.
+  include    = ["rules/(alerting|recording)/.+"]
+
+  # Ignore all *.md and *.txt files.
+  exclude    = [".+.md", ".+.txt"]
+}

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"regexp"
 )
 
 type CI struct {
@@ -17,18 +16,12 @@ func (ci CI) validate() error {
 		return errors.New("maxCommits cannot be <= 0")
 	}
 
-	for _, pattern := range ci.Include {
-		_, err := regexp.Compile(pattern)
-		if err != nil {
-			return err
-		}
+	if err := ValidatePaths(ci.Include); err != nil {
+		return err
+	}
+	if err := ValidatePaths(ci.Exclude); err != nil {
+		return err
 	}
 
-	for _, pattern := range ci.Exclude {
-		_, err := regexp.Compile(pattern)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ import (
 
 type Config struct {
 	CI         *CI                `hcl:"ci,block" json:"ci,omitempty"`
+	Lint       *Lint              `hcl:"lint,block" json:"lint,omitempty"`
 	Parser     *Parser            `hcl:"parser,block" json:"parser,omitempty"`
 	Repository *Repository        `hcl:"repository,block" json:"repository,omitempty"`
 	Discovery  *Discovery         `hcl:"discovery,block" json:"discovery,omitempty"`
@@ -220,6 +221,7 @@ func Load(path string, failOnMissing bool) (cfg Config, err error) {
 			MaxCommits: 20,
 			BaseBranch: "master",
 		},
+		Lint:   &Lint{},
 		Parser: &Parser{},
 		Checks: &Checks{
 			Enabled:  checks.CheckNames,

--- a/internal/config/lint.go
+++ b/internal/config/lint.go
@@ -1,0 +1,17 @@
+package config
+
+type Lint struct {
+	Include []string `hcl:"include,optional"       json:"include,omitempty"`
+	Exclude []string `hcl:"exclude,optional"       json:"exclude,omitempty"`
+}
+
+func (lint Lint) validate() error {
+	if err := ValidatePaths(lint.Include); err != nil {
+		return err
+	}
+	if err := ValidatePaths(lint.Exclude); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/config/lint_test.go
+++ b/internal/config/lint_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLintSettings(t *testing.T) {
+	type testCaseT struct {
+		err  error
+		conf Lint
+	}
+
+	testCases := []testCaseT{
+		{
+			conf: Lint{
+				Include: []string{"foo/.+"},
+				Exclude: []string{"foo/.+"},
+			},
+		},
+		{
+			conf: Lint{
+				Include: []string{".+++"},
+				Exclude: []string{"foo/.+"},
+			},
+			err: errors.New("error parsing regexp: invalid nested repetition operator: `++`"),
+		},
+		{
+			conf: Lint{
+				Include: []string{"foo/.+"},
+				Exclude: []string{".+++"},
+			},
+			err: errors.New("error parsing regexp: invalid nested repetition operator: `++`"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.conf), func(t *testing.T) {
+			err := tc.conf.validate()
+			if err == nil || tc.err == nil {
+				require.Equal(t, err, tc.err)
+			} else {
+				require.EqualError(t, err, tc.err.Error())
+			}
+		})
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"regexp"
+)
+
+func ValidatePaths(paths []string) error {
+	for _, pattern := range paths {
+		_, err := regexp.Compile(pattern)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePaths(t *testing.T) {
+	type testCaseT struct {
+		err   error
+		paths []string
+	}
+
+	testCases := []testCaseT{
+		{
+			paths: []string{"foo/.+"},
+		},
+		{
+			paths: []string{".+++"},
+			err:   errors.New("error parsing regexp: invalid nested repetition operator: `++`"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc.paths), func(t *testing.T) {
+			err := ValidatePaths(tc.paths)
+			if err == nil || tc.err == nil {
+				require.Equal(t, err, tc.err)
+			} else {
+				require.EqualError(t, err, tc.err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What

Allow the `.pint.hcl` to support a `lint` section for statically defining what rule to analyze.

# Why

The CI command supports includes and excludes, but forces the concept of delta-to-another-branch.
This several scenarios this simply doesn't work:
1. When using [merged_results_pipelines](https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html) there is no delta to compare against
2. Depending on the gitflow used, the target branch isn't always consistent

Additionally, when using linting as part of pre-commit, tracking the paths to the rules in pre-commit config seems like a muddling of responsibilities (the rules paths is a pint configuration, not a pre-commit one) 