### PR TITLE
feat: topk check

### DIFF
--- a/cmd/pint/tests/0005_false_positive.txt
+++ b/cmd/pint/tests/0005_false_positive.txt
@@ -5,6 +5,13 @@ cmp stderr stderr.txt
 -- stderr.txt --
 level=INFO msg="Loading configuration file" path=.pint.hcl
 level=INFO msg="Finding all rules to check" paths=["rules"]
+rules/0001.yml:2 Warning: usage of topk or bottomk in recording rules is discouraged and creates churn (rule/topk)
+ 2 |   expr: topk(6, sum(rate(edgeworker_subrequest_errorCount{cordon="free"}[5m])) BY (zoneId,job))
+
+rules/0001.yml:4 Warning: usage of topk or bottomk in recording rules is discouraged and creates churn (rule/topk)
+ 4 |   expr: topk(6, sum(rate(edgeworker_subrequest_errorCount{cordon="free"}[10m])) without (instance))
+
+level=INFO msg="Problems found" Warning=2
 -- rules/0001.yml --
 - record: "colo:test1"
   expr: topk(6, sum(rate(edgeworker_subrequest_errorCount{cordon="free"}[5m])) BY (zoneId,job))

--- a/cmd/pint/tests/0018_match_alerting.txt
+++ b/cmd/pint/tests/0018_match_alerting.txt
@@ -9,9 +9,9 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=2
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:recording lines=1-2
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=colo:recording
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=colo:recording
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=colo:alerting lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:alerting
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:alerting
 rules/0001.yml:5 Warning: Alert query doesn't have any condition, it will always fire if the metric exists. (alerts/comparison)
  5 |   expr: sum(bar) without(job)
 

--- a/cmd/pint/tests/0019_match_recording.txt
+++ b/cmd/pint/tests/0019_match_recording.txt
@@ -9,9 +9,9 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=2
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:recording lines=1-2
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:recording
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:recording
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=colo:alerting lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=colo:alerting
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=colo:alerting
 rules/0001.yml:2 Warning: `job` label is required and should be preserved when aggregating `^.+$` rules, remove job from `without()`. (promql/aggregate)
  2 |   expr: sum(foo) without(job)
 

--- a/cmd/pint/tests/0020_ignore_kind.txt
+++ b/cmd/pint/tests/0020_ignore_kind.txt
@@ -9,9 +9,9 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=2
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:recording lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:recording
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:recording
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=colo:alerting lines=7-8
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=colo:alerting
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=colo:alerting
 rules/0001.yml:5 Warning: `job` label is required and should be preserved when aggregating `^.+$` rules, remove job from `without()`. (promql/aggregate)
  5 |     expr: sum(foo) without(job)
 

--- a/cmd/pint/tests/0025_config.txt
+++ b/cmd/pint/tests/0025_config.txt
@@ -36,7 +36,8 @@ level=INFO msg="Loading configuration file" path=.pint.hcl
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ],
     "disabled": [
       "promql/fragile"

--- a/cmd/pint/tests/0037_disable_checks.txt
+++ b/cmd/pint/tests/0037_disable_checks.txt
@@ -11,11 +11,11 @@ level=INFO msg="Configured new Prometheus server" name=prom uris=1 uptime=up tag
 level=DEBUG msg="Starting query workers" name=prom uri=http://127.0.0.1 workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=1
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=default-for lines=1-3
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/template","promql/fragile","promql/regexp","promql/vector_matching(prom)","rule/duplicate(prom)","labels/conflict(prom)"] path=rules/0001.yml rule=default-for
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/vector_matching(prom)","rule/duplicate(prom)","labels/conflict(prom)"] path=rules/0001.yml rule=default-for
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:job lines=5-6
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/template","promql/fragile","promql/regexp","promql/vector_matching(prom)","rule/duplicate(prom)","labels/conflict(prom)","promql/aggregate(job:true)"] path=rules/0001.yml rule=sum:job
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/vector_matching(prom)","rule/duplicate(prom)","labels/conflict(prom)","promql/aggregate(job:true)"] path=rules/0001.yml rule=sum:job
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=no-comparison lines=8-9
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/template","promql/fragile","promql/regexp","promql/vector_matching(prom)","rule/duplicate(prom)","labels/conflict(prom)"] path=rules/0001.yml rule=no-comparison
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/vector_matching(prom)","rule/duplicate(prom)","labels/conflict(prom)"] path=rules/0001.yml rule=no-comparison
 rules/0001.yml:6 Warning: `job` label is required and should be preserved when aggregating `^.+$` rules, use `by(job, ...)`. (promql/aggregate)
  6 |   expr: sum(foo)
 

--- a/cmd/pint/tests/0039_prom_selected_path.txt
+++ b/cmd/pint/tests/0039_prom_selected_path.txt
@@ -11,11 +11,11 @@ level=INFO msg="Configured new Prometheus server" name=disabled uris=1 uptime=up
 level=DEBUG msg="Starting query workers" name=disabled uri=http://127.0.0.1:123 workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=1
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=first lines=1-3
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=first
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=first
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=second lines=5-6
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=second
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=second
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=third lines=8-9
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=third
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=third
 rules/0001.yml:6 Warning: `job` label is required and should be preserved when aggregating `^.+$` rules, use `by(job, ...)`. (promql/aggregate)
  6 |   expr: sum(bar)
 

--- a/cmd/pint/tests/0040_rule_match_label.txt
+++ b/cmd/pint/tests/0040_rule_match_label.txt
@@ -9,13 +9,13 @@ level=DEBUG msg="File parsed" path=rules/rules.yml rules=4
 level=DEBUG msg="Glob finder completed" count=4
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/rules.yml record=ignore lines=1-2
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/rules.yml rule=ignore
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/rules.yml rule=ignore
 level=DEBUG msg="Found recording rule" path=rules/rules.yml record=match lines=4-7
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/rules.yml rule=match
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/rules.yml rule=match
 level=DEBUG msg="Found alerting rule" path=rules/rules.yml alert=ignore lines=9-10
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/rules.yml rule=ignore
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/rules.yml rule=ignore
 level=DEBUG msg="Found alerting rule" path=rules/rules.yml alert=match lines=12-15
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/rules.yml rule=match
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/rules.yml rule=match
 rules/rules.yml:5 Warning: `job` label is required and should be preserved when aggregating `^.*$` rules, use `by(job, ...)`. (promql/aggregate)
  5 |   expr: sum(foo)
 

--- a/cmd/pint/tests/0042_watch_metrics.txt
+++ b/cmd/pint/tests/0042_watch_metrics.txt
@@ -143,6 +143,8 @@ pint_check_duration_seconds_sum{check="promql/regexp"}
 pint_check_duration_seconds_count{check="promql/regexp"}
 pint_check_duration_seconds_sum{check="promql/syntax"}
 pint_check_duration_seconds_count{check="promql/syntax"}
+pint_check_duration_seconds_sum{check="rule/topk"}
+pint_check_duration_seconds_count{check="rule/topk"}
 # HELP pint_check_iterations_total Total number of completed check iterations since pint start
 # TYPE pint_check_iterations_total counter
 pint_check_iterations_total

--- a/cmd/pint/tests/0052_match_multiple.txt
+++ b/cmd/pint/tests/0052_match_multiple.txt
@@ -9,9 +9,9 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=2
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:recording lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:recording
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:recording
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=colo:alerting lines=7-8
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:alerting
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=colo:alerting
 rules/0001.yml:5 Warning: `job` label is required and should be preserved when aggregating `^.+$` rules, remove job from `without()`. (promql/aggregate)
  5 |     expr: sum(foo) without(job)
 

--- a/cmd/pint/tests/0053_ignore_multiple.txt
+++ b/cmd/pint/tests/0053_ignore_multiple.txt
@@ -9,9 +9,9 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=2
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:recording lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=colo:recording
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=colo:recording
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=colo:alerting lines=7-8
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=colo:alerting
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=colo:alerting
 -- rules/0001.yml --
 groups:
 - name: foo

--- a/cmd/pint/tests/0054_watch_metrics_prometheus.txt
+++ b/cmd/pint/tests/0054_watch_metrics_prometheus.txt
@@ -70,6 +70,8 @@ pint_check_duration_seconds_sum{check="promql/vector_matching"}
 pint_check_duration_seconds_count{check="promql/vector_matching"}
 pint_check_duration_seconds_sum{check="rule/duplicate"}
 pint_check_duration_seconds_count{check="rule/duplicate"}
+pint_check_duration_seconds_sum{check="rule/topk"}
+pint_check_duration_seconds_count{check="rule/topk"}
 # HELP pint_check_iterations_total Total number of completed check iterations since pint start
 # TYPE pint_check_iterations_total counter
 pint_check_iterations_total

--- a/cmd/pint/tests/0057_watch_metrics_prometheus_ignore.txt
+++ b/cmd/pint/tests/0057_watch_metrics_prometheus_ignore.txt
@@ -68,6 +68,8 @@ pint_check_duration_seconds_sum{check="promql/vector_matching"}
 pint_check_duration_seconds_count{check="promql/vector_matching"}
 pint_check_duration_seconds_sum{check="rule/duplicate"}
 pint_check_duration_seconds_count{check="rule/duplicate"}
+pint_check_duration_seconds_sum{check="rule/topk"}
+pint_check_duration_seconds_count{check="rule/topk"}
 # HELP pint_check_iterations_total Total number of completed check iterations since pint start
 # TYPE pint_check_iterations_total counter
 pint_check_iterations_total

--- a/cmd/pint/tests/0092_dir_symlink.txt
+++ b/cmd/pint/tests/0092_dir_symlink.txt
@@ -13,7 +13,7 @@ level=DEBUG msg="File parsed" path=rules/src/rule.yaml rules=1
 level=DEBUG msg="Glob finder completed" count=1
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/src/rule.yaml record=down lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/src/rule.yaml rule=down
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/src/rule.yaml rule=down
 -- rules/src/rule.yaml --
 groups:
 - name: foo

--- a/cmd/pint/tests/0095_rulefmt_symlink.txt
+++ b/cmd/pint/tests/0095_rulefmt_symlink.txt
@@ -13,9 +13,9 @@ level=DEBUG msg="File parsed" path=rules/strict/symlink.yml rules=1
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/relaxed/1.yml record=foo lines=1-2
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/relaxed/1.yml rule=foo
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/relaxed/1.yml rule=foo
 level=DEBUG msg="Found recording rule" path=rules/strict/symlink.yml record=foo lines=1-2
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/strict/symlink.yml rule=foo
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/strict/symlink.yml rule=foo
 -- rules/relaxed/1.yml --
 - record: foo
   expr: up == 0

--- a/cmd/pint/tests/0099_symlink_outside_glob.txt
+++ b/cmd/pint/tests/0099_symlink_outside_glob.txt
@@ -12,7 +12,7 @@ level=DEBUG msg="File parsed" path=rules/relaxed/1.yml rules=1
 level=DEBUG msg="Glob finder completed" count=1
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/relaxed/1.yml record=foo lines=1-2
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/relaxed/1.yml rule=foo
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/relaxed/1.yml rule=foo
 -- rules/relaxed/1.yml --
 - record: foo
   expr: up == 0

--- a/cmd/pint/tests/0103_file_disable.txt
+++ b/cmd/pint/tests/0103_file_disable.txt
@@ -11,7 +11,7 @@ level=INFO msg="Configured new Prometheus server" name=prom uris=1 uptime=up tag
 level=DEBUG msg="Starting query workers" name=prom uri=http://127.0.0.1:7103 workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=1
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:test1 lines=9-10
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/vector_matching(prom)","labels/conflict(prom)","alerts/external_labels(prom)"] path=rules/0001.yml rule=colo:test1
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/vector_matching(prom)","labels/conflict(prom)","alerts/external_labels(prom)"] path=rules/0001.yml rule=colo:test1
 level=DEBUG msg="Stopping query workers" name=prom uri=http://127.0.0.1:7103
 -- rules/0001.yml --
 # This should skip all online checks

--- a/cmd/pint/tests/0111_snooze.txt
+++ b/cmd/pint/tests/0111_snooze.txt
@@ -10,7 +10,7 @@ level=DEBUG msg="Glob finder completed" count=1
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:job lines=2-3
 level=DEBUG msg="Check snoozed by comment" check=promql/aggregate(job:true) match=promql/aggregate until="2099-11-28T10:24:18Z"
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=sum:job
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=sum:job
 -- rules/0001.yml --
 # pint snooze 2099-11-28T10:24:18Z promql/aggregate
 - record: sum:job

--- a/cmd/pint/tests/0112_expired_snooze.txt
+++ b/cmd/pint/tests/0112_expired_snooze.txt
@@ -9,7 +9,7 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=1
 level=DEBUG msg="Glob finder completed" count=1
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:job lines=2-3
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","promql/aggregate(job:true)"] path=rules/0001.yml rule=sum:job
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","promql/aggregate(job:true)"] path=rules/0001.yml rule=sum:job
 rules/0001.yml:3 Bug: `job` label is required and should be preserved when aggregating `^.+$` rules, use `by(job, ...)`. (promql/aggregate)
  3 |   expr: sum(foo)
 

--- a/cmd/pint/tests/0113_config_env_expand.txt
+++ b/cmd/pint/tests/0113_config_env_expand.txt
@@ -41,7 +41,8 @@ level=INFO msg="Loading configuration file" path=.pint.hcl
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},

--- a/cmd/pint/tests/0115_file_disable_tag.txt
+++ b/cmd/pint/tests/0115_file_disable_tag.txt
@@ -11,7 +11,7 @@ level=INFO msg="Configured new Prometheus server" name=prom uris=1 uptime=up tag
 level=DEBUG msg="Starting query workers" name=prom uri=http://127.0.0.1:7103 workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=1
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=colo:test1 lines=6-8
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","alerts/external_labels(prom)","promql/counter(prom)"] path=rules/0001.yml rule=colo:test1
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk","alerts/external_labels(prom)","promql/counter(prom)"] path=rules/0001.yml rule=colo:test1
 level=DEBUG msg="Scheduling Prometheus metrics metadata query" uri=http://127.0.0.1:7103 metric=foo
 level=DEBUG msg="Getting prometheus metrics metadata" uri=http://127.0.0.1:7103 metric=foo
 level=ERROR msg="Query returned an error" err="failed to query Prometheus metrics metadata: Get \"http://127.0.0.1:7103/api/v1/metadata?metric=foo\": dial tcp 127.0.0.1:7103: connect: connection refused" uri=http://127.0.0.1:7103 query=foo

--- a/cmd/pint/tests/0116_file_snooze.txt
+++ b/cmd/pint/tests/0116_file_snooze.txt
@@ -11,9 +11,9 @@ level=DEBUG msg="File parsed" path=rules/0001.yml rules=2
 level=DEBUG msg="Glob finder completed" count=2
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:job lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=sum:job
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=sum:job
 level=DEBUG msg="Found alerting rule" path=rules/0001.yml alert=Down lines=7-9
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=Down
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=Down
 -- rules/0001.yml --
 # pint file/snooze 2099-11-28T10:24:18Z promql/aggregate(job:true)
 # pint file/snooze 2099-11-28T10:24:18Z alerts/for

--- a/cmd/pint/tests/0144_discovery_filepath.txt
+++ b/cmd/pint/tests/0144_discovery_filepath.txt
@@ -28,7 +28,7 @@ level=DEBUG msg="Starting query workers" name=prom2 uri=https://prom2.example.co
 level=DEBUG msg="Starting query workers" name=prom2 uri=https://prom2-backup.example.com workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=2
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:up lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=sum:up
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=sum:up
 level=DEBUG msg="Stopping query workers" name=prom1 uri=https://prom1.example.com
 level=DEBUG msg="Stopping query workers" name=prom1 uri=https://prom1-backup.example.com
 level=DEBUG msg="Stopping query workers" name=prom2 uri=https://prom2.example.com

--- a/cmd/pint/tests/0148_discovery_prom_zero.txt
+++ b/cmd/pint/tests/0148_discovery_prom_zero.txt
@@ -18,7 +18,7 @@ level=DEBUG msg="Parsed response" uri=http://127.0.0.1:7148 query=prometheus_rea
 level=DEBUG msg="Stopping query workers" name=discovery uri=http://127.0.0.1:7148
 level=DEBUG msg="Generated all Prometheus servers" count=0
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:up lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=sum:up
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=sum:up
 -- rules/0001.yml --
 groups:
 - name: foo

--- a/cmd/pint/tests/0149_discovery_prom.txt
+++ b/cmd/pint/tests/0149_discovery_prom.txt
@@ -24,7 +24,7 @@ level=DEBUG msg="Starting query workers" name=prom-ha uri=https://prom1.example.
 level=DEBUG msg="Starting query workers" name=prom-ha uri=https://prom2.example.com workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=1
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:up lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=sum:up
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=sum:up
 level=DEBUG msg="Stopping query workers" name=prom-ha uri=https://prom1.example.com
 level=DEBUG msg="Stopping query workers" name=prom-ha uri=https://prom2.example.com
 -- rules/0001.yml --

--- a/cmd/pint/tests/0152_discovery_prom_dup_uptime.txt
+++ b/cmd/pint/tests/0152_discovery_prom_dup_uptime.txt
@@ -32,7 +32,7 @@ level=DEBUG msg="Starting query workers" name=prom-ha uri=https://prom1.example.
 level=DEBUG msg="Starting query workers" name=prom-ha uri=https://prom2.example.com workers=16
 level=DEBUG msg="Generated all Prometheus servers" count=1
 level=DEBUG msg="Found recording rule" path=rules/0001.yml record=sum:up lines=4-5
-level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp"] path=rules/0001.yml rule=sum:up
+level=DEBUG msg="Configured checks for rule" enabled=["promql/syntax","alerts/for","alerts/comparison","alerts/template","promql/fragile","promql/regexp","rule/topk"] path=rules/0001.yml rule=sum:up
 level=DEBUG msg="Stopping query workers" name=prom-ha uri=https://prom1.example.com
 level=DEBUG msg="Stopping query workers" name=prom-ha uri=https://prom2.example.com
 -- rules/0001.yml --

--- a/docs/checks/rule/topk.md
+++ b/docs/checks/rule/topk.md
@@ -1,0 +1,55 @@
+---
+layout: default
+parent: Checks
+grand_parent: Documentation
+---
+
+# rule/topk
+
+This checks disallows the usage of `topk` or `bottomk` in recording rules.
+It is not configurable and will trigger if `topk` or `bottomk` is found in any
+part of a recording rule. It will not effect alerting rules.
+
+## Configuration
+
+This check doesn't have any configuration options.
+
+## How to enable it
+
+This check is enabled by default.
+
+## How to disable it
+
+You can disable this check globally by adding this config block:
+
+```js
+checks {
+  disabled = ["rule/topk"]
+}
+```
+
+You can also disable it for all rules inside given file by adding
+a comment anywhere in that file. Example:
+
+```yaml
+# pint file/disable rule/topk
+```
+
+Or you can disable it per rule by adding a comment to it. Example:
+
+```yaml
+# pint disable rule/topk
+```
+
+## How to snooze it
+
+You can disable this check until given time by adding a comment to it. Example:
+
+```yaml
+# pint snooze $TIMESTAMP rule/topk
+```
+
+Where `$TIMESTAMP` is either use [RFC3339](https://www.rfc-editor.org/rfc/rfc3339)
+formatted  or `YYYY-MM-DD`.
+Adding this comment will disable `rule/topk` *until* `$TIMESTAMP`, after that
+check will be re-enabled.

--- a/internal/checks/base.go
+++ b/internal/checks/base.go
@@ -35,6 +35,7 @@ var (
 		LabelCheckName,
 		RuleLinkCheckName,
 		RejectCheckName,
+		RuleTopkCheckName,
 	}
 	OnlineChecks = []string{
 		AlertsCheckName,

--- a/internal/checks/rule_topk.go
+++ b/internal/checks/rule_topk.go
@@ -1,0 +1,73 @@
+package checks
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/cloudflare/pint/internal/discovery"
+	"github.com/cloudflare/pint/internal/parser"
+)
+
+const (
+	RuleTopkCheckName    = "rule/topk"
+	TopkCheckRuleDetails = `Using topk or bottomk in recording rules can mean the series in the recording rule change frequently.
+This leads to high series churn which negatively impacts Prometheus performance and consumes more storage. It is generally not advisable to use topk or bottomk in recording rules unless the result is expected to be consistent.
+`
+)
+
+func NewRuleTopkCheck() RuleTopkCheck {
+	return RuleTopkCheck{}
+}
+
+type RuleTopkCheck struct{}
+
+func (c RuleTopkCheck) Meta() CheckMeta {
+	return CheckMeta{
+		States: []discovery.ChangeType{
+			discovery.Added,
+			discovery.Modified,
+			discovery.Noop,
+		},
+		IsOnline: false,
+	}
+}
+
+func (c RuleTopkCheck) String() string {
+	return RuleTopkCheckName
+}
+
+func (c RuleTopkCheck) Reporter() string {
+	return RuleTopkCheckName
+}
+
+func (c RuleTopkCheck) Check(_ context.Context, _ discovery.Path, rule parser.Rule, _ []discovery.Entry) (problems []Problem) {
+
+	if rule.RecordingRule == nil || rule.RecordingRule.Expr.SyntaxError != nil {
+		return nil
+	}
+
+	if rule.RecordingRule != nil {
+		slog.Debug("found recording rule, trying check", slog.String("rule", "topk"))
+		problems = append(problems, c.checkRecordingRule(rule)...)
+	}
+
+	return problems
+}
+
+func (c RuleTopkCheck) checkRecordingRule(rule parser.Rule) (problems []Problem) {
+
+	if strings.Contains(rule.RecordingRule.Expr.Value.Value, "topk") || strings.Contains(rule.RecordingRule.Expr.Value.Value, "bottomk") {
+		slog.Debug("check triggered, problem  found", slog.String("rule", "topk"))
+		problems = append(problems, Problem{
+			Lines:    rule.RecordingRule.Expr.Value.Lines,
+			Reporter: c.Reporter(),
+			Text:     "usage of topk or bottomk in recording rules is discouraged and creates churn",
+			Details:  TopkCheckRuleDetails,
+			Severity: Warning,
+		})
+	} else {
+		slog.Debug("no problem found", slog.String("rule", "topk"))
+	}
+	return problems
+}

--- a/internal/checks/rule_topk.go
+++ b/internal/checks/rule_topk.go
@@ -41,7 +41,6 @@ func (c RuleTopkCheck) Reporter() string {
 }
 
 func (c RuleTopkCheck) Check(_ context.Context, _ discovery.Path, rule parser.Rule, _ []discovery.Entry) (problems []Problem) {
-
 	if rule.RecordingRule == nil || rule.RecordingRule.Expr.SyntaxError != nil {
 		return nil
 	}
@@ -54,7 +53,6 @@ func (c RuleTopkCheck) Check(_ context.Context, _ discovery.Path, rule parser.Ru
 }
 
 func (c RuleTopkCheck) checkRecordingRule(rule parser.Rule) (problems []Problem) {
-
 	if strings.Contains(rule.RecordingRule.Expr.Value.Value, "topk") || strings.Contains(rule.RecordingRule.Expr.Value.Value, "bottomk") {
 		problems = append(problems, Problem{
 			Lines:    rule.RecordingRule.Expr.Value.Lines,

--- a/internal/checks/rule_topk.go
+++ b/internal/checks/rule_topk.go
@@ -2,7 +2,6 @@ package checks
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 
 	"github.com/cloudflare/pint/internal/discovery"
@@ -48,7 +47,6 @@ func (c RuleTopkCheck) Check(_ context.Context, _ discovery.Path, rule parser.Ru
 	}
 
 	if rule.RecordingRule != nil {
-		slog.Debug("found recording rule, trying check", slog.String("rule", "topk"))
 		problems = append(problems, c.checkRecordingRule(rule)...)
 	}
 
@@ -58,7 +56,6 @@ func (c RuleTopkCheck) Check(_ context.Context, _ discovery.Path, rule parser.Ru
 func (c RuleTopkCheck) checkRecordingRule(rule parser.Rule) (problems []Problem) {
 
 	if strings.Contains(rule.RecordingRule.Expr.Value.Value, "topk") || strings.Contains(rule.RecordingRule.Expr.Value.Value, "bottomk") {
-		slog.Debug("check triggered, problem  found", slog.String("rule", "topk"))
 		problems = append(problems, Problem{
 			Lines:    rule.RecordingRule.Expr.Value.Lines,
 			Reporter: c.Reporter(),
@@ -66,8 +63,6 @@ func (c RuleTopkCheck) checkRecordingRule(rule parser.Rule) (problems []Problem)
 			Details:  TopkCheckRuleDetails,
 			Severity: Warning,
 		})
-	} else {
-		slog.Debug("no problem found", slog.String("rule", "topk"))
 	}
 	return problems
 }

--- a/internal/checks/rule_topk_test.go
+++ b/internal/checks/rule_topk_test.go
@@ -1,0 +1,113 @@
+package checks_test
+
+import (
+	"testing"
+
+	"github.com/cloudflare/pint/internal/checks"
+	"github.com/cloudflare/pint/internal/parser"
+	"github.com/cloudflare/pint/internal/promapi"
+)
+
+func topkProblem() string {
+	return "usage of topk or bottomk in recording rules is discouraged and creates churn"
+}
+
+func TestRuleTopkCheck(t *testing.T) {
+	testCases := []checkTest{
+		{
+			description: "recording rule without topk or bottomk",
+			content:     "- record: foo\n  expr: sum(foo)\n",
+			checker: func(_ *promapi.FailoverGroup) checks.RuleChecker {
+				return checks.NewRuleTopkCheck()
+			},
+			prometheus: noProm,
+			problems:   noProblems,
+		},
+		{
+			description: "recording rule with topk",
+			content:     "- record: foo\n  expr: topk(5, up)\n",
+			checker: func(_ *promapi.FailoverGroup) checks.RuleChecker {
+				return checks.NewRuleTopkCheck()
+			},
+			prometheus: noProm,
+			problems: func(_ string) []checks.Problem {
+				return []checks.Problem{
+					{
+						Lines: parser.LineRange{
+							First: 2,
+							Last:  2,
+						},
+						Reporter: "rule/topk",
+						Text:     topkProblem(),
+						Severity: checks.Warning,
+						Details:  checks.TopkCheckRuleDetails,
+					},
+				}
+			},
+		},
+		{
+			description: "recording rule with bottomk",
+			content:     "- record: foo\n  expr: bottomk(5, up)\n",
+			checker: func(_ *promapi.FailoverGroup) checks.RuleChecker {
+				return checks.NewRuleTopkCheck()
+			},
+			prometheus: noProm,
+			problems: func(_ string) []checks.Problem {
+				return []checks.Problem{
+					{
+						Lines: parser.LineRange{
+							First: 2,
+							Last:  2,
+						},
+						Reporter: "rule/topk",
+						Text:     topkProblem(),
+						Severity: checks.Warning,
+						Details:  checks.TopkCheckRuleDetails,
+					},
+				}
+			},
+		},
+		{
+			description: "recording rule with nested topk",
+			content:     "- record: foo\n  expr: sum(topk(5, up))\n",
+			checker: func(_ *promapi.FailoverGroup) checks.RuleChecker {
+				return checks.NewRuleTopkCheck()
+			},
+			prometheus: noProm,
+			problems: func(_ string) []checks.Problem {
+				return []checks.Problem{
+					{
+						Lines: parser.LineRange{
+							First: 2,
+							Last:  2,
+						},
+						Reporter: "rule/topk",
+						Text:     topkProblem(),
+						Severity: checks.Warning,
+						Details:  checks.TopkCheckRuleDetails,
+					},
+				}
+			},
+		},
+		{
+			description: "alerting rule that shouldn't trigger",
+			content:     "- alert: foo\n  expr: foo\n  for: abc\n",
+			checker: func(_ *promapi.FailoverGroup) checks.RuleChecker {
+				return checks.NewRuleTopkCheck()
+			},
+			prometheus: noProm,
+			problems:   noProblems,
+		},
+		{
+			description: "syntax error that shouldn't trigger",
+			content:     "- record: foo\n  expr: rate(topk(5, up)[5m])\n",
+			checker: func(_ *promapi.FailoverGroup) checks.RuleChecker {
+				return checks.NewRuleTopkCheck()
+			},
+			prometheus: noProm,
+			problems:   noProblems,
+		},
+	}
+
+	runTests(t, testCases)
+}

--- a/internal/config/__snapshots__/config_test.snap
+++ b/internal/config/__snapshots__/config_test.snap
@@ -160,7 +160,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {}
@@ -198,7 +199,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -250,7 +252,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -305,7 +308,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -357,7 +361,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -398,7 +403,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -457,7 +463,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -517,7 +524,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -528,102 +536,6 @@
         "severity": "warning",
         "maxSeries": 10000
       }
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/duplicated_rules - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "label": [
-        {
-          "key": "team",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    },
-    {
-      "annotation": [
-        {
-          "key": "summary",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    },
-    {
-      "annotation": [
-        {
-          "key": "summary",
-          "severity": "bug",
-          "required": true
-        }
-      ],
-      "label": [
-        {
-          "key": "team",
-          "comment": "this is rule comment",
-          "severity": "warning"
-        }
-      ]
-    },
-    {
-      "annotation": [
-        {
-          "key": "summary",
-          "value": "foo.+",
-          "comment": "this is rule comment",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    },
-    {
-      "annotation": [
-        {
-          "key": "summary",
-          "token": "\\w+",
-          "value": "foo.+",
-          "severity": "bug",
-          "required": true
-        }
-      ]
     }
   ]
 }
@@ -660,7 +572,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -720,7 +633,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -740,508 +654,6 @@
           "key": "priority",
           "value": "(1|2|3|4|5)",
           "severity": "bug",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/rule_with_label_match_/_no_label - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "label": {
-            "key": "cluster",
-            "value": "prod"
-          },
-          "kind": "alerting"
-        }
-      ],
-      "label": [
-        {
-          "key": "priority",
-          "value": "(1|2|3|4|5)",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/rule_with_label_match_/_label_mismatch - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "label": {
-            "key": "cluster",
-            "value": "prod"
-          },
-          "kind": "alerting"
-        }
-      ],
-      "label": [
-        {
-          "key": "priority",
-          "value": "(1|2|3|4|5)",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/rule_with_annotation_match_/_no_annotation - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "annotation": {
-            "key": "cluster",
-            "value": "prod"
-          },
-          "kind": "alerting"
-        }
-      ],
-      "label": [
-        {
-          "key": "priority",
-          "value": "(1|2|3|4|5)",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/rule_with_annotation_match_/_annotation_mismatch - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "annotation": {
-            "key": "cluster",
-            "value": "prod"
-          },
-          "kind": "alerting"
-        }
-      ],
-      "label": [
-        {
-          "key": "priority",
-          "value": "(1|2|3|4|5)",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_match_/_passing - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "for": "\u003e 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_match_/_not_passing - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "for": "\u003e 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
-          "comment": "this is rule comment",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_match_/_passing#01 - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "keep_firing_for": "\u003e 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_match_/_passing#02 - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "keep_firing_for": "\u003e 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_match_/_passing#03 - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "keep_firing_for": "\u003e 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
           "required": true
         }
       ]
@@ -1281,7 +693,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1295,113 +708,6 @@
       "annotation": [
         {
           "key": "summary",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_ignore_/_passing - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "ignore": [
-        {
-          "for": "\u003c 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/for_ignore_/_not_passing - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "ignore": [
-        {
-          "for": "\u003c 15m"
-        }
-      ],
-      "annotation": [
-        {
-          "key": "summary",
-          "comment": "this is rule comment",
           "required": true
         }
       ]
@@ -1441,7 +747,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1494,7 +801,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1510,126 +818,6 @@
           },
           "comment": "this is rule comment",
           "severity": "bug"
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/rule_with_label_match_/_label_match - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "label": {
-            "key": "cluster",
-            "value": "prod"
-          },
-          "kind": "alerting"
-        }
-      ],
-      "label": [
-        {
-          "key": "priority",
-          "value": "(1|2|3|4|5)",
-          "severity": "bug",
-          "required": true
-        }
-      ]
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/rule_with_annotation_match_/_annotation_match - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "rules": [
-    {
-      "match": [
-        {
-          "annotation": {
-            "key": "cluster",
-            "value": "prod"
-          },
-          "kind": "alerting"
-        }
-      ],
-      "label": [
-        {
-          "key": "priority",
-          "token": "\\w+",
-          "value": "(1|2|3|4|5)",
-          "comment": "this is rule comment",
-          "severity": "bug",
-          "required": true
         }
       ]
     }
@@ -1668,7 +856,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1717,7 +906,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1770,7 +960,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1822,7 +1013,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1886,7 +1078,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -1955,7 +1148,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ],
     "disabled": [
       "alerts/template",
@@ -1981,90 +1175,6 @@
       "concurrency": 16,
       "rateLimit": 100,
       "required": false
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/multiple_cost_checks - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ]
-  },
-  "owners": {},
-  "prometheus": [
-    {
-      "name": "prom1",
-      "uri": "http://localhost",
-      "timeout": "1s",
-      "uptime": "up",
-      "include": [
-        "rules.yml"
-      ],
-      "concurrency": 16,
-      "rateLimit": 100,
-      "required": false
-    },
-    {
-      "name": "prom2",
-      "uri": "http://localhost",
-      "timeout": "1s",
-      "uptime": "up",
-      "include": [
-        "rules.yml"
-      ],
-      "concurrency": 16,
-      "rateLimit": 100,
-      "required": false
-    }
-  ],
-  "rules": [
-    {
-      "cost": {
-        "comment": "this is rule comment",
-        "severity": "info"
-      }
-    },
-    {
-      "cost": {
-        "severity": "warning",
-        "maxSeries": 10000
-      }
-    },
-    {
-      "cost": {
-        "severity": "bug",
-        "maxSeries": 20000
-      }
     }
   ]
 }
@@ -2101,7 +1211,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ],
     "disabled": [
       "promql/counter",
@@ -2205,73 +1316,12 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ],
     "disabled": [
       "alerts/template",
       "alerts/external_labels"
-    ]
-  },
-  "owners": {},
-  "prometheus": [
-    {
-      "name": "prom1",
-      "uri": "http://localhost/1",
-      "timeout": "1s",
-      "uptime": "up",
-      "concurrency": 16,
-      "rateLimit": 100,
-      "required": false
-    },
-    {
-      "name": "prom2",
-      "uri": "http://localhost/2",
-      "timeout": "1s",
-      "uptime": "up",
-      "concurrency": 16,
-      "rateLimit": 100,
-      "required": false
-    }
-  ]
-}
----
-
-[TestGetChecksForRule/two_prometheus_servers_/_expired_snooze - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ],
-    "disabled": [
-      "alerts/template",
-      "promql/regexp"
     ]
   },
   "owners": {},
@@ -2329,7 +1379,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -2404,7 +1455,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -2462,7 +1514,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -2506,68 +1559,6 @@
 }
 ---
 
-[TestGetChecksForRule/two_prometheus_servers_/_snoozed_checks_via_comment - 1]
-{
-  "ci": {
-    "baseBranch": "master",
-    "maxCommits": 20
-  },
-  "parser": {},
-  "checks": {
-    "enabled": [
-      "alerts/annotation",
-      "alerts/count",
-      "alerts/external_labels",
-      "alerts/for",
-      "alerts/template",
-      "labels/conflict",
-      "promql/aggregate",
-      "alerts/comparison",
-      "promql/fragile",
-      "promql/range_query",
-      "promql/rate",
-      "promql/regexp",
-      "promql/syntax",
-      "promql/vector_matching",
-      "query/cost",
-      "promql/counter",
-      "promql/series",
-      "rule/dependency",
-      "rule/duplicate",
-      "rule/for",
-      "rule/label",
-      "rule/link",
-      "rule/reject"
-    ],
-    "disabled": [
-      "alerts/template",
-      "promql/regexp"
-    ]
-  },
-  "owners": {},
-  "prometheus": [
-    {
-      "name": "prom1",
-      "uri": "http://localhost/1",
-      "timeout": "1s",
-      "uptime": "up",
-      "concurrency": 16,
-      "rateLimit": 100,
-      "required": false
-    },
-    {
-      "name": "prom2",
-      "uri": "http://localhost/2",
-      "timeout": "1s",
-      "uptime": "up",
-      "concurrency": 16,
-      "rateLimit": 100,
-      "required": false
-    }
-  ]
-}
----
-
 [TestGetChecksForRule/alerts/count_full - 1]
 {
   "ci": {
@@ -2599,7 +1590,8 @@
       "rule/for",
       "rule/label",
       "rule/link",
-      "rule/reject"
+      "rule/reject",
+      "rule/topk"
     ]
   },
   "owners": {},
@@ -2624,6 +1616,1056 @@
         "severity": "bug",
         "minCount": 100
       }
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/duplicated_rules - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "label": [
+        {
+          "key": "team",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    },
+    {
+      "annotation": [
+        {
+          "key": "summary",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    },
+    {
+      "annotation": [
+        {
+          "key": "summary",
+          "severity": "bug",
+          "required": true
+        }
+      ],
+      "label": [
+        {
+          "key": "team",
+          "comment": "this is rule comment",
+          "severity": "warning"
+        }
+      ]
+    },
+    {
+      "annotation": [
+        {
+          "key": "summary",
+          "value": "foo.+",
+          "comment": "this is rule comment",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    },
+    {
+      "annotation": [
+        {
+          "key": "summary",
+          "token": "\\w+",
+          "value": "foo.+",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/rule_with_label_match_/_no_label - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "label": {
+            "key": "cluster",
+            "value": "prod"
+          },
+          "kind": "alerting"
+        }
+      ],
+      "label": [
+        {
+          "key": "priority",
+          "value": "(1|2|3|4|5)",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/rule_with_label_match_/_label_mismatch - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "label": {
+            "key": "cluster",
+            "value": "prod"
+          },
+          "kind": "alerting"
+        }
+      ],
+      "label": [
+        {
+          "key": "priority",
+          "value": "(1|2|3|4|5)",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/rule_with_label_match_/_label_match - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "label": {
+            "key": "cluster",
+            "value": "prod"
+          },
+          "kind": "alerting"
+        }
+      ],
+      "label": [
+        {
+          "key": "priority",
+          "value": "(1|2|3|4|5)",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/rule_with_annotation_match_/_no_annotation - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "annotation": {
+            "key": "cluster",
+            "value": "prod"
+          },
+          "kind": "alerting"
+        }
+      ],
+      "label": [
+        {
+          "key": "priority",
+          "value": "(1|2|3|4|5)",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/rule_with_annotation_match_/_annotation_mismatch - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "annotation": {
+            "key": "cluster",
+            "value": "prod"
+          },
+          "kind": "alerting"
+        }
+      ],
+      "label": [
+        {
+          "key": "priority",
+          "value": "(1|2|3|4|5)",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/rule_with_annotation_match_/_annotation_match - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "annotation": {
+            "key": "cluster",
+            "value": "prod"
+          },
+          "kind": "alerting"
+        }
+      ],
+      "label": [
+        {
+          "key": "priority",
+          "token": "\\w+",
+          "value": "(1|2|3|4|5)",
+          "comment": "this is rule comment",
+          "severity": "bug",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_match_/_passing - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "for": "\u003e 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_match_/_not_passing - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "for": "\u003e 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "comment": "this is rule comment",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_match_/_passing#01 - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "keep_firing_for": "\u003e 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_match_/_passing#02 - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "keep_firing_for": "\u003e 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_match_/_passing#03 - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "match": [
+        {
+          "keep_firing_for": "\u003e 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_ignore_/_passing - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "ignore": [
+        {
+          "for": "\u003c 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/for_ignore_/_not_passing - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "rules": [
+    {
+      "ignore": [
+        {
+          "for": "\u003c 15m"
+        }
+      ],
+      "annotation": [
+        {
+          "key": "summary",
+          "comment": "this is rule comment",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/multiple_cost_checks - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ]
+  },
+  "owners": {},
+  "prometheus": [
+    {
+      "name": "prom1",
+      "uri": "http://localhost",
+      "timeout": "1s",
+      "uptime": "up",
+      "include": [
+        "rules.yml"
+      ],
+      "concurrency": 16,
+      "rateLimit": 100,
+      "required": false
+    },
+    {
+      "name": "prom2",
+      "uri": "http://localhost",
+      "timeout": "1s",
+      "uptime": "up",
+      "include": [
+        "rules.yml"
+      ],
+      "concurrency": 16,
+      "rateLimit": 100,
+      "required": false
+    }
+  ],
+  "rules": [
+    {
+      "cost": {
+        "comment": "this is rule comment",
+        "severity": "info"
+      }
+    },
+    {
+      "cost": {
+        "severity": "warning",
+        "maxSeries": 10000
+      }
+    },
+    {
+      "cost": {
+        "severity": "bug",
+        "maxSeries": 20000
+      }
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/two_prometheus_servers_/_snoozed_checks_via_comment - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ],
+    "disabled": [
+      "alerts/template",
+      "promql/regexp"
+    ]
+  },
+  "owners": {},
+  "prometheus": [
+    {
+      "name": "prom1",
+      "uri": "http://localhost/1",
+      "timeout": "1s",
+      "uptime": "up",
+      "concurrency": 16,
+      "rateLimit": 100,
+      "required": false
+    },
+    {
+      "name": "prom2",
+      "uri": "http://localhost/2",
+      "timeout": "1s",
+      "uptime": "up",
+      "concurrency": 16,
+      "rateLimit": 100,
+      "required": false
+    }
+  ]
+}
+---
+
+[TestGetChecksForRule/two_prometheus_servers_/_expired_snooze - 1]
+{
+  "ci": {
+    "baseBranch": "master",
+    "maxCommits": 20
+  },
+  "parser": {},
+  "checks": {
+    "enabled": [
+      "alerts/annotation",
+      "alerts/count",
+      "alerts/external_labels",
+      "alerts/for",
+      "alerts/template",
+      "labels/conflict",
+      "promql/aggregate",
+      "alerts/comparison",
+      "promql/fragile",
+      "promql/range_query",
+      "promql/rate",
+      "promql/regexp",
+      "promql/syntax",
+      "promql/vector_matching",
+      "query/cost",
+      "promql/counter",
+      "promql/series",
+      "rule/dependency",
+      "rule/duplicate",
+      "rule/for",
+      "rule/label",
+      "rule/link",
+      "rule/reject",
+      "rule/topk"
+    ],
+    "disabled": [
+      "alerts/template",
+      "promql/regexp"
+    ]
+  },
+  "owners": {},
+  "prometheus": [
+    {
+      "name": "prom1",
+      "uri": "http://localhost/1",
+      "timeout": "1s",
+      "uptime": "up",
+      "concurrency": 16,
+      "rateLimit": 100,
+      "required": false
+    },
+    {
+      "name": "prom2",
+      "uri": "http://localhost/2",
+      "timeout": "1s",
+      "uptime": "up",
+      "concurrency": 16,
+      "rateLimit": 100,
+      "required": false
     }
   ]
 }

--- a/internal/config/alerts.go
+++ b/internal/config/alerts.go
@@ -40,7 +40,7 @@ func (as AlertsSettings) validate() error {
 			return err
 		}
 		if as.MinCount <= 0 && sev > checks.Information {
-			return fmt.Errorf("cannot set serverity to %q when minCount is 0", as.Severity)
+			return fmt.Errorf("cannot set severity to %q when minCount is 0", as.Severity)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,6 +112,10 @@ func (cfg *Config) GetChecksForRule(ctx context.Context, gen *PrometheusGenerato
 			name:  checks.RuleDependencyCheckName,
 			check: checks.NewRuleDependencyCheck(),
 		},
+		{
+			name:  checks.RuleTopkCheckName,
+			check: checks.NewRuleTopkCheck(),
+		},
 	}
 
 	proms := gen.ServersForPath(entry.Path.Name)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1095,6 +1095,7 @@ prometheus "prom1" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.RateCheckName + "(prom1)",
 				checks.SeriesCheckName + "(prom1)",
 				checks.VectorMatchingCheckName + "(prom1)",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,6 +170,7 @@ func TestGetChecksForRule(t *testing.T) {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -194,7 +195,8 @@ prometheus "prom" {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom)",
 				checks.SeriesCheckName + "(prom)",
 				checks.VectorMatchingCheckName + "(prom)",
 				checks.RangeQueryCheckName + "(prom)",
@@ -227,7 +229,8 @@ prometheus "prom" {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom)",
 				checks.SeriesCheckName + "(prom)",
 				checks.VectorMatchingCheckName + "(prom)",
 				checks.RangeQueryCheckName + "(prom)",
@@ -276,6 +279,7 @@ checks {
 				checks.ComparisonCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -302,6 +306,7 @@ prometheus "prom" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -329,6 +334,7 @@ prometheus "prom" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -355,6 +361,7 @@ prometheus "prom" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -380,7 +387,8 @@ prometheus "prom" {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom)",
 				checks.SeriesCheckName + "(prom)",
 				checks.VectorMatchingCheckName + "(prom)",
 				checks.RangeQueryCheckName + "(prom)",
@@ -418,7 +426,8 @@ prometheus "ignore" {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom)",
 				checks.SeriesCheckName + "(prom)",
 				checks.VectorMatchingCheckName + "(prom)",
 				checks.RangeQueryCheckName + "(prom)",
@@ -446,6 +455,7 @@ prometheus "ignore" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -475,7 +485,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.AggregationCheckName + "(job:true)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.AggregationCheckName + "(job:true)",
 				checks.AggregationCheckName + "(instance:false)",
 				checks.AggregationCheckName + "(rack:false)",
 			},
@@ -512,7 +523,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.AggregationCheckName + "(job:true)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.AggregationCheckName + "(job:true)",
 				checks.AggregationCheckName + "(rack:false)",
 			},
 		},
@@ -542,6 +554,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -587,6 +600,7 @@ prometheus "prom2" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.RateCheckName + "(prom1)",
 				checks.RangeQueryCheckName + "(prom1)",
 				checks.LabelsConflictCheckName + "(prom1)",
@@ -656,7 +670,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.LabelCheckName + "(team:true)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.LabelCheckName + "(team:true)",
 				checks.AnnotationCheckName + "(summary:true)",
 				checks.LabelCheckName + "(team:false)",
 				checks.AnnotationCheckName + "(summary=~^foo.+$:true)",
@@ -713,6 +728,7 @@ rule {
 - record: foo
   # pint disable promql/fragile
   # pint disable promql/regexp
+  # pint disable rule/topk
   expr: sum(foo)
 `),
 			},
@@ -763,7 +779,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RejectCheckName + "(key=~'^http://.+$')",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RejectCheckName + "(key=~'^http://.+$')",
 				checks.RejectCheckName + "(val=~'^http://.+$')",
 				checks.RejectCheckName + "(key=~'^.* +.*$')",
 				checks.RejectCheckName + "(val=~'^$')",
@@ -801,6 +818,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -835,6 +853,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -869,6 +888,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -902,7 +922,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.LabelCheckName + "(priority=~^(1|2|3|4|5)$:true)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.LabelCheckName + "(priority=~^(1|2|3|4|5)$:true)",
 			},
 		},
 		{
@@ -937,6 +958,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -971,6 +993,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -1006,7 +1029,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.LabelCheckName + "(priority=~^(1|2|3|4|5)$:true)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.LabelCheckName + "(priority=~^(1|2|3|4|5)$:true)",
 			},
 		},
 		{
@@ -1054,6 +1078,7 @@ prometheus "prom1" {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.AlertsExternalLabelsCheckName + "(prom1)",
 				checks.AlertsCheckName + "(prom1)",
 			},
@@ -1253,6 +1278,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.AnnotationCheckName + "(summary:true)",
 			},
 		},
@@ -1284,6 +1310,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -1313,6 +1340,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.AnnotationCheckName + "(summary:true)",
 			},
 		},
@@ -1343,6 +1371,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -1372,6 +1401,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -1401,6 +1431,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -1430,6 +1461,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.AnnotationCheckName + "(summary:true)",
 			},
 		},
@@ -1461,6 +1493,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 		},
 		{
@@ -1490,6 +1523,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.AnnotationCheckName + "(summary:true)",
 			},
 		},
@@ -1523,6 +1557,7 @@ rule {
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 				checks.RuleLinkCheckName + "(^https?://(.+)$)",
 			},
 		},
@@ -1562,6 +1597,7 @@ checks {
 				checks.ComparisonCheckName,
 				checks.FragileCheckName,
 				checks.RegexpCheckName,
+				checks.RuleTopkCheckName,
 			},
 			disabledChecks: []string{"promql/rate", "promql/vector_matching", "rule/duplicate", "labels/conflict", "promql/counter"},
 		},
@@ -1595,6 +1631,7 @@ checks {
 # pint snooze 2099-11-28 rule/duplicate
 # pint snooze 2099-11-28T00:00:00+00:00 promql/vector_matching
 # pint snooze 2099-11-28 promql/counter
+# pint snooze 2099-11-28 rule/topk
 - record: foo
   expr: sum(foo)
 # pint file/disable promql/vector_matching
@@ -1649,6 +1686,7 @@ checks {
 				checks.AlertForCheckName,
 				checks.ComparisonCheckName,
 				checks.FragileCheckName,
+				checks.RuleTopkCheckName,
 				checks.SeriesCheckName + "(prom1)",
 				checks.VectorMatchingCheckName + "(prom1)",
 				checks.RangeQueryCheckName + "(prom1)",
@@ -1709,7 +1747,8 @@ prometheus "prom3" {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom2)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom2)",
 				checks.SeriesCheckName + "(prom2)",
 				checks.VectorMatchingCheckName + "(prom2)",
 				checks.RangeQueryCheckName + "(prom2)",
@@ -1770,7 +1809,8 @@ prometheus "prom3" {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom2)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom2)",
 				checks.SeriesCheckName + "(prom2)",
 				checks.VectorMatchingCheckName + "(prom2)",
 				checks.RangeQueryCheckName + "(prom2)",
@@ -1818,7 +1858,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom)",
 				checks.SeriesCheckName + "(prom)",
 				checks.VectorMatchingCheckName + "(prom)",
 				checks.RangeQueryCheckName + "(prom)",
@@ -1862,7 +1903,8 @@ rule {
 				checks.ComparisonCheckName,
 				checks.TemplateCheckName,
 				checks.FragileCheckName,
-				checks.RegexpCheckName, checks.RateCheckName + "(prom)",
+				checks.RegexpCheckName,
+				checks.RuleTopkCheckName, checks.RateCheckName + "(prom)",
 				checks.SeriesCheckName + "(prom)",
 				checks.VectorMatchingCheckName + "(prom)",
 				checks.RangeQueryCheckName + "(prom)",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1994,7 +1994,7 @@ func TestConfigErrors(t *testing.T) {
 	severity = "bug"
   }
 }`,
-			err: `cannot set serverity to "bug" when minCount is 0`,
+			err: `cannot set severity to "bug" when minCount is 0`,
 		},
 		{
 			config: `rule {
@@ -2208,7 +2208,7 @@ func TestConfigErrors(t *testing.T) {
 	}
 }
 
-func TestDuplicatedPrometeusName(t *testing.T) {
+func TestDuplicatedPrometheusName(t *testing.T) {
 	dir := t.TempDir()
 	path := path.Join(dir, "config.hcl")
 	err := os.WriteFile(path, []byte(`


### PR DESCRIPTION
This adds a new check to warn against the use of `topk` or `bottomk` in
recording rules. This is an anti-pattern as these operators lead to high
churn as the time series the recording rule generates will change
frequently as the conditions for topk/bottomk adjust.

It is enabled by default with a warning severity. It will only fire for
recording rules, not alerting rules.

Resolves #820