### PR TITLE
Add fallback error text

### DIFF
--- a/internal/promapi/config.go
+++ b/internal/promapi/config.go
@@ -118,6 +118,7 @@ func streamConfig(r io.Reader) (cfg PrometheusConfig, err error) {
 	defer dummyReadAll(r)
 
 	var yamlBody, status, errType, errText string
+	errText = "empty response object"
 	decoder := current.Object(
 		current.Key("status", current.Value(func(s string, _ bool) {
 			status = s

--- a/internal/promapi/flags.go
+++ b/internal/promapi/flags.go
@@ -97,6 +97,7 @@ func streamFlags(r io.Reader) (flags v1.FlagsResult, err error) {
 	defer dummyReadAll(r)
 
 	var status, errType, errText string
+	errText = "empty response object"
 	flags = v1.FlagsResult{}
 	decoder := current.Object(
 		current.Key("status", current.Value(func(s string, _ bool) {

--- a/internal/promapi/metadata.go
+++ b/internal/promapi/metadata.go
@@ -103,6 +103,7 @@ func streamMetadata(r io.Reader) (meta map[string][]v1.Metadata, err error) {
 	defer dummyReadAll(r)
 
 	var status, errType, errText string
+	errText = "empty response object"
 	meta = map[string][]v1.Metadata{}
 	decoder := current.Object(
 		current.Key("status", current.Value(func(s string, _ bool) {

--- a/internal/promapi/metadata_test.go
+++ b/internal/promapi/metadata_test.go
@@ -48,6 +48,10 @@ func TestMetadata(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			time.Sleep(time.Second * 2)
 			_, _ = w.Write([]byte(`{"status":"success","data":{"once":[{"type":"gauge","help":"Text","unit":""}]}}`))
+		case "empty":
+			w.WriteHeader(200)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
 		case "error":
 			w.WriteHeader(500)
 			_, _ = w.Write([]byte("fake error\n"))
@@ -98,6 +102,11 @@ func TestMetadata(t *testing.T) {
 			metric:  "slow",
 			timeout: time.Millisecond * 10,
 			err:     "connection timeout",
+		},
+		{
+			metric:  "empty",
+			timeout: time.Second,
+			err:     "unknown: empty response object",
 		},
 		{
 			metric:  "error",

--- a/internal/promapi/query.go
+++ b/internal/promapi/query.go
@@ -115,6 +115,7 @@ func streamSamples(r io.Reader) (samples []Sample, stats QueryStats, err error) 
 	defer dummyReadAll(r)
 
 	var status, resultType, errType, errText string
+	errText = "empty response object"
 	samples = []Sample{}
 	var sample model.Sample
 	decoder := current.Object(

--- a/internal/promapi/range.go
+++ b/internal/promapi/range.go
@@ -280,6 +280,7 @@ func streamSampleStream(r io.Reader, step time.Duration) (dst MetricTimeRanges, 
 	defer dummyReadAll(r)
 
 	var status, errType, errText, resultType string
+	errText = "empty response object"
 	var sample model.SampleStream
 	decoder := current.Object(
 		current.Key("status", current.Value(func(s string, _ bool) {


### PR DESCRIPTION
If the JSON object has no error key then we end up with empty error message, add fallback.