### PR TITLE
Revert "Force colored output unless explicitly disabled"

### DIFF
--- a/cmd/pint/logger.go
+++ b/cmd/pint/logger.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fatih/color"
-
 	"github.com/cloudflare/pint/internal/log"
 )
 
@@ -18,10 +16,6 @@ func initLogger(level string, noColor bool) error {
 	nc := os.Getenv("NO_COLOR")
 	if nc != "" && nc != "0" {
 		noColor = true
-	}
-	// Override fatih/color detection of when to **disable** coloring.
-	if !noColor {
-		color.NoColor = false
 	}
 
 	log.Setup(l, noColor)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.65.4
+
+### Fixed
+
+- Reverted `Fixed colored output on some environments - #1106` change
+  as it was breaking GitHub report comments.
+
 ## v0.65.3
 
 ### Fixed


### PR DESCRIPTION
This reverts commit c5dcd86850c6f534ed06fec3a1b21f3a126a39a3.