### PR TITLE
fix creating GitLab comments on unmodified lines

### DIFF
--- a/internal/reporter/gitlab.go
+++ b/internal/reporter/gitlab.go
@@ -155,10 +155,7 @@ func (gl GitLabReporter) Summary(ctx context.Context, dst any, s Summary, errs [
 
 func (gl GitLabReporter) List(ctx context.Context, dst any) ([]ExistingComment, error) {
 	mr := dst.(gitlabMR)
-	slog.Debug("Getting the list of merge request discussions", slog.Int("mr", mr.mrID))
-	reqCtx, cancel := context.WithTimeout(ctx, gl.timeout)
-	defer cancel()
-	discs, _, err := gl.client.Discussions.ListMergeRequestDiscussions(gl.project, mr.mrID, nil, gitlab.WithContext(reqCtx))
+	discs, err := gl.getDiscussions(ctx, mr.mrID)
 	if err != nil {
 		return nil, err
 	}
@@ -311,6 +308,18 @@ func (gl *GitLabReporter) getVersions(ctx context.Context, mrNum int) (*gitlab.M
 		return nil, errors.New("no merge request versions found")
 	}
 	return vers[0], nil
+}
+
+func (gl *GitLabReporter) getDiscussions(ctx context.Context, mrNum int) ([]*gitlab.Discussion, error) {
+	slog.Debug("Getting the list of merge request discussions", slog.Int("mr", mrNum))
+	discs, _, err := getGitLabPaginated(func(pageNum int) ([]*gitlab.Discussion, *gitlab.Response, error) {
+		reqCtx, cancel := context.WithTimeout(ctx, gl.timeout)
+		defer cancel()
+		return gl.client.Discussions.ListMergeRequestDiscussions(gl.project, mrNum, &gitlab.ListMergeRequestDiscussionsOptions{
+			Page: pageNum,
+		}, gitlab.WithContext(reqCtx))
+	})
+	return discs, err
 }
 
 func (gl GitLabReporter) generalComment(ctx context.Context, mrNum int, msg string) error {

--- a/internal/reporter/gitlab.go
+++ b/internal/reporter/gitlab.go
@@ -359,17 +359,17 @@ func reportToGitLabDiscussion(pending PendingComment, diffs []*gitlab.MergeReque
 	switch {
 	case !ok:
 		// No diffLine for this line, most likely unmodified ?.
-		d.Position.NewLine = gitlab.Ptr(dl.new)
-		d.Position.OldLine = gitlab.Ptr(dl.old)
+		d.Position.NewLine = gitlab.Ptr(pending.line)
+		d.Position.OldLine = gitlab.Ptr(pending.line)
 	case pending.anchor == checks.AnchorBefore:
 		// Comment on removed line.
 		d.Position.OldLine = gitlab.Ptr(dl.old)
 	case ok && !dl.wasModified:
-		// Commend on unmodified line.
+		// Comment on unmodified line.
 		d.Position.NewLine = gitlab.Ptr(dl.new)
 		d.Position.OldLine = gitlab.Ptr(dl.old)
 	default:
-		// Commend on new or modified line.
+		// Comment on new or modified line.
 		d.Position.NewLine = gitlab.Ptr(dl.new)
 	}
 
@@ -392,10 +392,37 @@ type diffLine struct {
 }
 
 func diffLineFor(lines []diffLine, line int) (diffLine, bool) {
-	for _, dl := range lines {
+	if len(lines) == 0 {
+		return diffLine{}, false
+	}
+
+	for i, dl := range lines {
 		if dl.new == line {
 			return dl, true
 		}
+		// Calculate unmodified line that does not present in the diff
+		if dl.new > line {
+			lastLines := dl
+			if i > 0 {
+				lastLines = lines[i-1]
+			}
+			gap := line - lastLines.new
+			return diffLine{
+				old:         lastLines.old + gap,
+				new:         line,
+				wasModified: false,
+			}, true
+		}
+	}
+	// Calculate unmodified line that is greater than the last diff line
+	lastLines := lines[len(lines)-1]
+	if line > lastLines.new {
+		gap := line - lastLines.new
+		return diffLine{
+			old:         lastLines.old + gap,
+			new:         line,
+			wasModified: false,
+		}, true
 	}
 	return diffLine{}, false
 }


### PR DESCRIPTION
This pull request fixes some issues with GitLab Reporter:

- get all existing comments using pagination
- fixing incorrect request `new_line=0,old_line=0` if comment should be created on unmodified line that doesn't exist in the diff

Added extra tests for different cases for creating comments in GitLab.