### PR TITLE
feat: introduce a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/pre-commit-hooks.json
+- id: pint
+  name: validate prometheus rules with pint
+  language: golang
+  entry: pint --offline lint
+  types:
+    - yaml


### PR DESCRIPTION
https://pre-commit.com/ is a framework to run CI tools with git pre-commit hooks.

Before this PR, it's a bit painful to integrate `pint` in pre-commit. It looks like this:

      - id: pint
        name: Validate prometheus rules with pint
        language: golang
        additional_dependencies:
          - github.com/cloudflare/pint/cmd/pint@v0.69.1
        entry: pint --offline lint
        types:
          - yaml
        files: ^helm/context/rules/

[Some context](https://perrotta.dev/2024/12/pre-commit-create-hooks-for-unsupported-tools/).

After this PR, clients can trivially adopt `pint` in their repos:

    - repo: https://github.com/cloudflare/pint
      rev: v0.69.1
      hooks:
        - id: pint
          files: ^helm/mychart/rules/

...which is the idiomatic way to integrate pre-commit hooks.

I tested this locally with my work and it works as intended:

```
% pre-commit run --all-files pint
pint.....................................................................Passed
```