### PR TITLE
fix: stop github reporter deleting other PR comments

### DIFF
--- a/cmd/pint/tests/0032_ci_github.txt
+++ b/cmd/pint/tests/0032_ci_github.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
@@ -73,6 +74,12 @@ rule {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/1/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -92,7 +99,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -116,6 +123,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 3
 side: RIGHT
@@ -129,7 +138,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -147,6 +156,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 3
 side: RIGHT
@@ -160,7 +171,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/aggregate** check.
 
     <details>
@@ -182,6 +193,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/aggregate.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 8
 side: RIGHT

--- a/cmd/pint/tests/0033_ci_github_multi.txt
+++ b/cmd/pint/tests/0033_ci_github_multi.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
@@ -67,6 +68,12 @@ repository {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/1/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -86,7 +93,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **alerts/template** check.
 
     <details>
@@ -122,6 +129,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/template.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 4
 side: RIGHT
@@ -135,7 +144,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -170,6 +179,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 2
 side: RIGHT

--- a/cmd/pint/tests/0069_bitbucket_unmodified.txt
+++ b/cmd/pint/tests/0069_bitbucket_unmodified.txt
@@ -98,7 +98,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -133,6 +133,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -147,7 +149,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/regexp** check.
 
     <details>
@@ -178,6 +180,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/regexp.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -192,7 +196,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -221,6 +225,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0070_bitbucket_strict.txt
+++ b/cmd/pint/tests/0070_bitbucket_strict.txt
@@ -75,7 +75,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **yaml/parse** check.
 
     ------
@@ -93,6 +93,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/yaml/parse.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0071_ci_owner.txt
+++ b/cmd/pint/tests/0071_ci_owner.txt
@@ -97,7 +97,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **rule/owner** check.
 
     <details>
@@ -126,6 +126,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/owner.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -140,7 +142,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -164,6 +166,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0072_bitbucket_move_bug_to_modified.txt
+++ b/cmd/pint/tests/0072_bitbucket_move_bug_to_modified.txt
@@ -76,7 +76,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **yaml/parse** check.
 
     ------
@@ -94,6 +94,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/yaml/parse.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0075_ci_strict.txt
+++ b/cmd/pint/tests/0075_ci_strict.txt
@@ -73,7 +73,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **rule/owner** check.
 
     <details>
@@ -91,6 +91,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/owner.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -105,7 +107,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **promql/syntax** check.
 
     <details>
@@ -125,6 +127,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/syntax.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0076_ci_group_errors.txt
+++ b/cmd/pint/tests/0076_ci_group_errors.txt
@@ -246,7 +246,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **alerts/annotation** check.
 
     <details>
@@ -280,6 +280,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/annotation.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -294,7 +296,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **rule/label** check.
 
     <details>
@@ -326,6 +328,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/label.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -340,7 +344,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **rule/owner** check.
 
     <details>
@@ -376,6 +380,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/owner.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -390,7 +396,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **promql/syntax** check.
 
     <details>
@@ -410,6 +416,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/syntax.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -424,7 +432,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -461,6 +469,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -475,7 +485,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -493,6 +503,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -507,7 +519,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **alerts/template** check.
 
     <details>
@@ -532,6 +544,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/template.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -546,7 +560,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **alerts/template** check.
 
     <details>
@@ -564,6 +578,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/template.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -578,7 +594,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/regexp** check.
 
     <details>
@@ -598,6 +614,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/regexp.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -612,7 +630,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **promql/aggregate** check.
 
     <details>
@@ -632,6 +650,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/aggregate.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0083_github_action.txt
+++ b/cmd/pint/tests/0083_github_action.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/foo/bar/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/foo/bar/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/foo/bar/pulls/123/comments 200 []
@@ -64,6 +65,12 @@ groups:
 repository {}
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/foo/bar/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -83,7 +90,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -107,6 +114,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 6
 side: RIGHT
@@ -120,7 +129,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -138,6 +147,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 6
 side: RIGHT

--- a/cmd/pint/tests/0084_github_action_override.txt
+++ b/cmd/pint/tests/0084_github_action_override.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/123/comments 200 []
@@ -67,6 +68,12 @@ repository {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -86,7 +93,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -110,6 +117,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 6
 side: RIGHT
@@ -123,7 +132,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -141,6 +150,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 6
 side: RIGHT

--- a/cmd/pint/tests/0085_github_no_envs.txt
+++ b/cmd/pint/tests/0085_github_no_envs.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/123/comments 200 []
@@ -62,6 +63,12 @@ repository {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -81,7 +88,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -105,6 +112,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 6
 side: RIGHT
@@ -118,7 +127,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -136,6 +145,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 6
 side: RIGHT

--- a/cmd/pint/tests/0093_ci_bitbucket_ignore_file.txt
+++ b/cmd/pint/tests/0093_ci_bitbucket_ignore_file.txt
@@ -78,7 +78,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **ignore/file** check.
 
     <details>
@@ -96,6 +96,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/ignore/file.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0094_rule_file_symlink_bb.txt
+++ b/cmd/pint/tests/0094_rule_file_symlink_bb.txt
@@ -125,7 +125,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **promql/rate** check.
 
     <details>
@@ -154,6 +154,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/rate.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -168,7 +170,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **promql/rate** check.
 
     <details>
@@ -197,6 +199,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/rate.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0098_rule_file_symlink_gh.txt
+++ b/cmd/pint/tests/0098_rule_file_symlink_gh.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
@@ -62,6 +63,12 @@ repository {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/1/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -81,7 +88,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -116,6 +123,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 7
 side: RIGHT

--- a/cmd/pint/tests/0100_ci_alerts_count.txt
+++ b/cmd/pint/tests/0100_ci_alerts_count.txt
@@ -104,7 +104,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/count** check.
 
     <details>
@@ -135,6 +135,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/count.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0118_ci_dir_move.txt
+++ b/cmd/pint/tests/0118_ci_dir_move.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
@@ -55,6 +56,12 @@ repository {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/1/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip

--- a/cmd/pint/tests/0119_ci_fail_on_warning.txt
+++ b/cmd/pint/tests/0119_ci_fail_on_warning.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
@@ -68,6 +69,12 @@ rule {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/1/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -87,7 +94,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **rule/label** check.
 
     <details>
@@ -107,6 +114,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/label.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 3
 side: RIGHT
@@ -120,7 +129,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -144,6 +153,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 3
 side: RIGHT
@@ -157,7 +168,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -175,6 +186,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 3
 side: RIGHT

--- a/cmd/pint/tests/0123_ci_owner_allowed.txt
+++ b/cmd/pint/tests/0123_ci_owner_allowed.txt
@@ -108,7 +108,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **rule/owner** check.
 
     <details>
@@ -126,6 +126,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/owner.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -140,7 +142,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/1/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **rule/owner** check.
 
     <details>
@@ -158,6 +160,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/owner.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0163_ci_comment_resolve_blocker.txt
+++ b/cmd/pint/tests/0163_ci_comment_resolve_blocker.txt
@@ -2,7 +2,7 @@ http response bitbucket /plugins/servlet/applinks/whoami 200 pint
 http response bitbucket /rest/api/1.0/projects/prometheus/repos/rules/commits/.*/pull-requests 200 {"size":1,"isLastPage":true,"values":[{"id":123,"open":true,"fromRef":{"id":"refs/heads/modify","latestCommit":"fake-commit-id"},"toRef":{"id":"refs/heads/main","latestCommit":"fake-commit-id"}}]}
 http response bitbucket /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/changes 200 {"values":[{"path":{"toString":"rules.yml"}}],"size":1,"isLastPage":true}
 http response bitbucket /rest/api/latest/projects/prometheus/repos/rules/commits/fake-commit-id/diff/rules.yml 200 {"diffs":[{"hunks":[{"segments":[{"type":"ADDED", "lines":[{"source":5,"destination":5}]}]}]}]}
-http response bitbucket /rest/api/latest/projects/prometheus/repos/rules/pull-requests/123/activities 200 {"size":1,"isLastPage":true,"values":[{"action":"COMMENTED","commentAction":"ADDED","commentAnchor":{"diffType":"EFFECTIVE","lineType":"ADDED","path":"rules.yml","line":5},"comment":{"id":1,"state":"OPEN","severity":"BLOCKER","author":{"name":"pint"},"comments":[{"id":2}]}}]}
+http response bitbucket /rest/api/latest/projects/prometheus/repos/rules/pull-requests/123/activities 200 {"size":1,"isLastPage":true,"values":[{"action":"COMMENTED","commentAction":"ADDED","commentAnchor":{"diffType":"EFFECTIVE","lineType":"ADDED","path":"rules.yml","line":5},"comment":{"id":1,"state":"OPEN","severity":"BLOCKER","text":"stale pint comment\n<!-- pint -->","author":{"name":"pint"},"comments":[{"id":2}]}}]}
 http response bitbucket /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/comments 200 {}
 http start bitbucket 127.0.0.1:7163
 
@@ -92,7 +92,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **promql/syntax** check.
 
     <details>
@@ -112,6 +112,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/syntax.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -151,7 +153,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **promql/syntax** check.
 
     <details>
@@ -171,6 +173,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/syntax.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0164_ci_comment_resolve_normal.txt
+++ b/cmd/pint/tests/0164_ci_comment_resolve_normal.txt
@@ -2,7 +2,7 @@ http response bitbucket /plugins/servlet/applinks/whoami 200 pint
 http response bitbucket /rest/api/1.0/projects/prometheus/repos/rules/commits/.*/pull-requests 200 {"size":1,"isLastPage":true,"values":[{"id":123,"open":true,"fromRef":{"id":"refs/heads/modify","latestCommit":"fake-commit-id"},"toRef":{"id":"refs/heads/main","latestCommit":"fake-commit-id"}}]}
 http response bitbucket /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/changes 200 {"values":[{"path":{"toString":"rules.yml"}}],"size":1,"isLastPage":true}
 http response bitbucket /rest/api/latest/projects/prometheus/repos/rules/commits/fake-commit-id/diff/rules.yml 200 {"diffs":[{"hunks":[{"segments":[{"type":"ADDED", "lines":[{"source":5,"destination":5}]}]}]}]}
-http response bitbucket /rest/api/latest/projects/prometheus/repos/rules/pull-requests/123/activities 200 {"size":1,"isLastPage":true,"values":[{"action":"COMMENTED","commentAction":"ADDED","commentAnchor":{"diffType":"EFFECTIVE","lineType":"ADDED","path":"rules.yml","line":5},"comment":{"id":1,"state":"OPEN","severity":"NORMAL","author":{"name":"pint"},"comments":[{"id":2}]}}]}
+http response bitbucket /rest/api/latest/projects/prometheus/repos/rules/pull-requests/123/activities 200 {"size":1,"isLastPage":true,"values":[{"action":"COMMENTED","commentAction":"ADDED","commentAnchor":{"diffType":"EFFECTIVE","lineType":"ADDED","path":"rules.yml","line":5},"comment":{"id":1,"state":"OPEN","severity":"NORMAL","text":"stale pint comment\n<!-- pint -->","author":{"name":"pint"},"comments":[{"id":2}]}}]}
 http response bitbucket /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/comments 200 {}
 http start bitbucket 127.0.0.1:7164
 
@@ -92,7 +92,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **promql/syntax** check.
 
     <details>
@@ -112,6 +112,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/syntax.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml
@@ -160,7 +162,7 @@ POST /rest/api/1.0/projects/prometheus/repos/rules/pull-requests/123/comments
   Authorization: Bearer "12345"
   Content-Type: application/json
 --- BODY ---
-text: |
+text: |-
     :stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **promql/syntax** check.
 
     <details>
@@ -180,6 +182,8 @@ text: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/syntax.html).
+
+    <!-- pint -->
 severity: NORMAL
 anchor:
     path: rules.yml

--- a/cmd/pint/tests/0213_ci_removed_rule.txt
+++ b/cmd/pint/tests/0213_ci_removed_rule.txt
@@ -84,7 +84,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **rule/dependency** check.
 
     ------
@@ -103,6 +103,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/dependency.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0218_ci_gitlab_delete_dependency_empty_diff.txt
+++ b/cmd/pint/tests/0218_ci_gitlab_delete_dependency_empty_diff.txt
@@ -126,7 +126,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **rule/dependency** check.
 
     ------
@@ -145,6 +145,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/dependency.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0219_ci_gitlab_delete_dependency.txt
+++ b/cmd/pint/tests/0219_ci_gitlab_delete_dependency.txt
@@ -126,7 +126,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **rule/dependency** check.
 
     ------
@@ -145,6 +145,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/dependency.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0222_ci_problem_context.txt
+++ b/cmd/pint/tests/0222_ci_problem_context.txt
@@ -87,7 +87,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/aggregate** check.
 
     <details>
@@ -109,6 +109,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/aggregate.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0244_ci_gitlab_rename.txt
+++ b/cmd/pint/tests/0244_ci_gitlab_rename.txt
@@ -82,7 +82,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -106,6 +106,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head
@@ -122,7 +124,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -140,6 +142,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0245_ci_gitlab_new_file.txt
+++ b/cmd/pint/tests/0245_ci_gitlab_new_file.txt
@@ -73,7 +73,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -97,6 +97,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0246_ci_github_new_file.txt
+++ b/cmd/pint/tests/0246_ci_github_new_file.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/foo/bar/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/foo/bar/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/foo/bar/pulls/123/comments 200 []
@@ -45,6 +46,12 @@ groups:
 repository {}
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/foo/bar/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -64,7 +71,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -88,6 +95,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 5
 side: RIGHT

--- a/cmd/pint/tests/0247_ci_github_rename.txt
+++ b/cmd/pint/tests/0247_ci_github_rename.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/foo/bar/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/foo/bar/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/foo/bar/pulls/123/comments 200 []
@@ -54,6 +55,12 @@ groups:
 repository {}
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/foo/bar/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -73,7 +80,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -97,6 +104,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: renamed.yml
 line: 6
 side: RIGHT
@@ -110,7 +119,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -128,6 +137,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: renamed.yml
 line: 6
 side: RIGHT

--- a/cmd/pint/tests/0248_ci_github_deleted_line.txt
+++ b/cmd/pint/tests/0248_ci_github_deleted_line.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/foo/bar/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/foo/bar/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/foo/bar/pulls/123/comments 200 []
@@ -96,6 +97,12 @@ prometheus "prom" {
 repository {}
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/foo/bar/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -115,7 +122,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **rule/dependency** check.
 
     ------
@@ -134,6 +141,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/rule/dependency.html).
+
+    <!-- pint -->
 path: record.yml
 line: 6
 side: LEFT

--- a/cmd/pint/tests/0249_ci_github_shifted_line.txt
+++ b/cmd/pint/tests/0249_ci_github_shifted_line.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/foo/bar/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/foo/bar/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/foo/bar/pulls/123/comments 200 []
@@ -55,6 +56,12 @@ groups:
 repository {}
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/foo/bar/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -74,7 +81,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -98,6 +105,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 8
 side: RIGHT
@@ -111,7 +120,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -129,6 +138,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 8
 side: RIGHT

--- a/cmd/pint/tests/0250_ci_gitlab_shifted_line.txt
+++ b/cmd/pint/tests/0250_ci_gitlab_shifted_line.txt
@@ -83,7 +83,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -107,6 +107,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head
@@ -123,7 +125,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -141,6 +143,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0251_ci_github_line_outside_diff.txt
+++ b/cmd/pint/tests/0251_ci_github_line_outside_diff.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/foo/bar/pulls/123/reviews 200 []
 http method github POST /api/v3/repos/foo/bar/pulls/123/reviews 200 {}
 http method github GET /api/v3/repos/foo/bar/pulls/123/comments 200 []
@@ -74,6 +75,12 @@ groups:
 repository {}
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/foo/bar/pulls/123/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -93,7 +100,7 @@ POST /api/v3/repos/foo/bar/pulls/123/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -117,6 +124,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 16
 side: RIGHT

--- a/cmd/pint/tests/0252_ci_gitlab_line_outside_diff.txt
+++ b/cmd/pint/tests/0252_ci_gitlab_line_outside_diff.txt
@@ -102,7 +102,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -126,6 +126,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0261_ci_gitlab_detached_head.txt
+++ b/cmd/pint/tests/0261_ci_gitlab_detached_head.txt
@@ -92,7 +92,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -116,6 +116,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head
@@ -132,7 +134,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :information_source: **Information** reported by [pint](https://cloudflare.github.io/pint/) **alerts/for** check.
 
     <details>
@@ -150,6 +152,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/for.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0269_ci_gitlab_long_expr.txt
+++ b/cmd/pint/tests/0269_ci_gitlab_long_expr.txt
@@ -106,7 +106,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **alerts/template** check.
 
     <details>
@@ -131,6 +131,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/template.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head
@@ -147,7 +149,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/impossible** check.
 
     <details>
@@ -172,6 +174,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/impossible.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head
@@ -188,7 +192,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/regexp** check.
 
     <details>
@@ -212,6 +216,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/regexp.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0270_ci_github_long_expr.txt
+++ b/cmd/pint/tests/0270_ci_github_long_expr.txt
@@ -1,3 +1,4 @@
+http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
@@ -83,6 +84,12 @@ repository {
 }
 
 -- github.expected --
+GET /api/v3/user
+  Accept: application/vnd.github.v3+json
+  Accept-Encoding: gzip
+  Authorization: Bearer 12345
+  X-Github-Api-Version: 2022-11-28
+
 GET /api/v3/repos/cloudflare/pint/pulls/1/comments
   Accept: application/vnd.github.squirrel-girl-preview, application/vnd.github.comfort-fade-preview+json
   Accept-Encoding: gzip
@@ -102,7 +109,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **alerts/template** check.
 
     <details>
@@ -127,6 +134,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/template.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 8
 side: RIGHT
@@ -140,7 +149,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/impossible** check.
 
     <details>
@@ -165,6 +174,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/impossible.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 8
 side: RIGHT
@@ -178,7 +189,7 @@ POST /api/v3/repos/cloudflare/pint/pulls/1/comments
   Content-Type: application/json
   X-Github-Api-Version: 2022-11-28
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **promql/regexp** check.
 
     <details>
@@ -202,6 +213,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/promql/regexp.html).
+
+    <!-- pint -->
 path: rules.yml
 line: 20
 side: RIGHT

--- a/cmd/pint/tests/0272_ci_gitlab_stale_general_comment.txt
+++ b/cmd/pint/tests/0272_ci_gitlab_stale_general_comment.txt
@@ -1,6 +1,6 @@
 http method gitlab GET /api/v4/user 200 {"id": 555}
 http method gitlab GET /api/v4/projects/1234/merge_requests/1/versions 200 [{"id": 2, "head_commit_sha": "head", "base_commit_sha": "base", "start_commit_sha": "start"},{"id": 1, "head_commit_sha": "head", "base_commit_sha": "base", "start_commit_sha": "start"}]
-http method gitlab GET /api/v4/projects/1234/merge_requests/1/discussions 200 [{"id": "500", "notes": [{"id": 501, "author": {"id": 555}, "system": false, "body": "stale general comment from previous pint run"}]}]
+http method gitlab GET /api/v4/projects/1234/merge_requests/1/discussions 200 [{"id": "500", "notes": [{"id": 501, "author": {"id": 555}, "system": false, "body": "This pint run would create 3 comment(s), which is more than the limit configured for pint (1). <!-- pint -->"}]}]
 http method gitlab GET /api/v4/projects/1234/merge_requests 200 [{"iid": 1}]
 http method gitlab PUT /api/v4/projects/1234/merge_requests/1/discussions/500 200 {}
 http start gitlab 127.0.0.1:6272

--- a/cmd/pint/tests/0276_ci_gitlab_added_symlink.txt
+++ b/cmd/pint/tests/0276_ci_gitlab_added_symlink.txt
@@ -76,7 +76,7 @@ POST /api/v4/projects/1234/merge_requests/1/discussions
   Content-Type: application/json
   Private-Token: secret
 --- BODY ---
-body: |
+body: |-
     :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
 
     <details>
@@ -102,6 +102,8 @@ body: |
     ------
 
     :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+
+    <!-- pint -->
 position:
     base_sha: base
     head_sha: head

--- a/cmd/pint/tests/0277_ci_github_keep_foreign_general_comments.txt
+++ b/cmd/pint/tests/0277_ci_github_keep_foreign_general_comments.txt
@@ -2,10 +2,9 @@ http method github GET /api/v3/user 200 {"id":42,"login":"ci-user"}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 []
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/reviews 200 {}
 http method github GET /api/v3/repos/cloudflare/pint/pulls/1/comments 200 []
-http method github GET /api/v3/repos/cloudflare/pint/issues/1/comments 200 [{"id":999,"body":"This pint run would create 3 comment(s), which is more than the limit configured for pint (1). <!-- pint -->","user":{"id":42,"login":"ci-user"}}]
+http method github GET /api/v3/repos/cloudflare/pint/issues/1/comments 200 [{"id":100,"body":"LGTM","user":{"id":7,"login":"reviewer"}},{"id":101,"body":"automated review comment","user":{"id":8,"login":"review-bot"}},{"id":102,"body":"workflow status comment","user":{"id":9,"login":"workflow-bot"}}]
 http method github POST /api/v3/repos/cloudflare/pint/pulls/1/comments 200 {}
-http method github DELETE /api/v3/repos/cloudflare/pint/issues/comments/999 200 {}
-http start github 127.0.0.1:6271
+http start github 127.0.0.1:6277
 
 mkdir testrepo
 cd testrepo
@@ -28,7 +27,7 @@ env GITHUB_AUTH_TOKEN=12345
 env GITHUB_PULL_REQUEST_NUMBER=1
 exec pint -l debug --offline --no-color ci
 ! stdout .
-stderr 'level=INFO msg="Deleting stale general comment" reporter=GitHub id=999'
+! stderr 'Deleting stale general comment'
 stderr 'level=INFO msg="Pull request review created" status="200 OK"'
 cmp github.got ../github.expected
 
@@ -53,8 +52,8 @@ parser {
 }
 repository {
   github {
-    baseuri   = "http://127.0.0.1:6271"
-    uploaduri = "http://127.0.0.1:6271"
+    baseuri   = "http://127.0.0.1:6277"
+    uploaduri = "http://127.0.0.1:6277"
     owner     = "cloudflare"
     repo      = "pint"
   }
@@ -75,12 +74,6 @@ GET /api/v3/repos/cloudflare/pint/pulls/1/comments
 
 GET /api/v3/repos/cloudflare/pint/issues/1/comments
   Accept: application/vnd.github.squirrel-girl-preview
-  Accept-Encoding: gzip
-  Authorization: Bearer 12345
-  X-Github-Api-Version: 2022-11-28
-
-DELETE /api/v3/repos/cloudflare/pint/issues/comments/999
-  Accept: application/vnd.github.v3+json
   Accept-Encoding: gzip
   Authorization: Bearer 12345
   X-Github-Api-Version: 2022-11-28

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,9 +18,10 @@
 
 - GitHub, GitLab, and BitBucket reporters were trying to create comments on
   incorrect lines for symlinked files.
-- GitHub reporter no longer deletes pull request comments it did not post
-  when removing outdated general comments. Cleanup is limited to comments
-  authored by the authenticated user that include pint's comment marker.
+- GitHub, GitLab, and BitBucket reporters no longer deletes pull request
+  comments it did not post when removing outdated general comments.
+  Cleanup is limited to comments authored by the authenticated user that
+  include hidden comment marker.
 
 ## v0.87.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@
 
 - GitHub, GitLab, and BitBucket reporters were trying to create comments on
   incorrect lines for symlinked files.
+- GitHub reporter no longer deletes pull request comments it did not post
+  when removing outdated general comments. Cleanup is limited to comments
+  authored by the authenticated user that include pint's comment marker.
 
 ## v0.87.0
 

--- a/internal/reporter/bitbucket.go
+++ b/internal/reporter/bitbucket.go
@@ -115,6 +115,10 @@ func (bb BitBucketReporter) Summary(
 	return nil
 }
 
+func (bb BitBucketReporter) UserID(ctx context.Context, _ any) (string, error) {
+	return bb.whoami(ctx)
+}
+
 func (bb BitBucketReporter) List(ctx context.Context, dst any) ([]ExistingComment, error) {
 	pr := dst.(*bitBucketPR)
 	bbComments, err := bb.getPullRequestComments(ctx, pr)
@@ -125,10 +129,11 @@ func (bb BitBucketReporter) List(ctx context.Context, dst any) ([]ExistingCommen
 	comments := make([]ExistingComment, 0, len(bbComments))
 	for _, c := range bbComments {
 		comments = append(comments, ExistingComment{
-			id:   strconv.Itoa(c.id),
-			path: c.anchor.Path,
-			text: c.text,
-			line: c.anchor.Line,
+			id:     strconv.Itoa(c.id),
+			path:   c.anchor.Path,
+			text:   c.text,
+			author: c.author,
+			line:   c.anchor.Line,
 			meta: bitBucketCommentMeta{
 				id:       c.id,
 				version:  c.version,
@@ -152,6 +157,7 @@ func (bb BitBucketReporter) Delete(ctx context.Context, dst any, c ExistingComme
 	meta := c.meta.(bitBucketCommentMeta)
 	bc := bitBucketComment{
 		text:     "",
+		author:   c.author,
 		severity: meta.severity,
 		anchor: BitBucketCommentAnchor{
 			Path:     "",
@@ -252,6 +258,7 @@ type bitBucketPR struct {
 
 type bitBucketComment struct {
 	text     string
+	author   string
 	severity string
 	anchor   BitBucketCommentAnchor
 	id       int
@@ -454,11 +461,6 @@ func (bb BitBucketReporter) findPullRequestForBranch(ctx context.Context, branch
 }
 
 func (bb BitBucketReporter) getPullRequestComments(ctx context.Context, pr *bitBucketPR) ([]bitBucketComment, error) {
-	username, err := bb.whoami(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	comments := []bitBucketComment{}
 
 	var start int
@@ -493,9 +495,6 @@ func (bb BitBucketReporter) getPullRequestComments(ctx context.Context, pr *bitB
 			if act.Comment.State != "OPEN" {
 				continue
 			}
-			if act.Comment.Author.Name != username {
-				continue
-			}
 			if act.Comment.Severity == "BLOCKER" && act.Comment.Resolved {
 				continue
 			}
@@ -506,6 +505,7 @@ func (bb BitBucketReporter) getPullRequestComments(ctx context.Context, pr *bitB
 				id:       act.Comment.ID,
 				version:  act.Comment.Version,
 				text:     act.Comment.Text,
+				author:   act.Comment.Author.Name,
 				anchor:   act.CommentAnchor,
 				severity: act.Comment.Severity,
 				replies:  len(act.Comment.Comments),
@@ -608,7 +608,7 @@ func (bb BitBucketReporter) postComment(ctx context.Context, pr *bitBucketPR, co
 
 func (bb BitBucketReporter) postGeneralComment(ctx context.Context, pr *bitBucketPR, text string) error {
 	comment := BitBucketPendingComment{
-		Text:     text,
+		Text:     AddPintMarker(text),
 		Severity: "NORMAL",
 		Anchor: BitBucketPendingCommentAnchor{
 			Path:     "",

--- a/internal/reporter/bitbucket_test.go
+++ b/internal/reporter/bitbucket_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cloudflare/pint/internal/reporter"
 )
 
-func bbCommentText(severity, reporter, summary string) string {
+func bbCommentText(severity, check, summary string) string {
 	icon := ":stop_sign:"
 	switch severity {
 	case "Warning":
@@ -30,7 +30,7 @@ func bbCommentText(severity, reporter, summary string) string {
 	case "Information":
 		icon = ":information_source:"
 	}
-	return icon + " **" + severity + "** reported by [pint](https://cloudflare.github.io/pint/) **" + reporter + "** check.\n\n------\n\n" + summary + "\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/" + reporter + ".html).\n"
+	return reporter.AddPintMarker(icon + " **" + severity + "** reported by [pint](https://cloudflare.github.io/pint/) **" + check + "** check.\n\n------\n\n" + summary + "\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/" + check + ".html).\n")
 }
 
 const (
@@ -223,7 +223,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "stale comment text",
+									Text:     reporter.AddPintMarker("stale comment text"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 								},
 								CommentAnchor: reporter.BitBucketCommentAnchor{
@@ -287,7 +287,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  3,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "stale comment with reply",
+									Text:     reporter.AddPintMarker("stale comment with reply"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 									Comments: []reporter.BitBucketPullRequestComment{
 										{ID: 201, Text: "reply"},
@@ -322,7 +322,7 @@ func TestBitBucketReporter(t *testing.T) {
 				s.ExpectGet(bbWhoami).ReturnCode(http.StatusInternalServerError)
 			}),
 			errorHandler: func(err error) error {
-				if err != nil && err.Error() == "GET request failed" {
+				if err != nil && err.Error() == "failed to get user details: GET request failed" {
 					return nil
 				}
 				return fmt.Errorf("unexpected error: %w", err)
@@ -606,7 +606,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "stale page 1",
+									Text:     reporter.AddPintMarker("stale page 1"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 								},
 								CommentAnchor: reporter.BitBucketCommentAnchor{
@@ -629,7 +629,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "stale page 2",
+									Text:     reporter.AddPintMarker("stale page 2"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 								},
 								CommentAnchor: reporter.BitBucketCommentAnchor{
@@ -693,7 +693,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "BLOCKER",
-									Text:     "stale blocker with reply",
+									Text:     reporter.AddPintMarker("stale blocker with reply"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 									Comments: []reporter.BitBucketPullRequestComment{
 										{ID: 651, Text: "a reply"},
@@ -764,7 +764,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  2,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "stale non-blocker with reply",
+									Text:     reporter.AddPintMarker("stale non-blocker with reply"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 									Comments: []reporter.BitBucketPullRequestComment{
 										{ID: 601, Text: "a reply"},
@@ -845,7 +845,7 @@ func TestBitBucketReporter(t *testing.T) {
 					ReturnCode(http.StatusCreated)
 				s.ExpectPost(bbComments).
 					WithBodyJSON(reporter.BitBucketPendingComment{
-						Text:     "This pint run would create 2 comment(s), which is more than the limit configured for pint (1).\n1 comment(s) were skipped and won't be visible on this PR.",
+						Text:     reporter.AddPintMarker("This pint run would create 2 comment(s), which is more than the limit configured for pint (1).\n1 comment(s) were skipped and won't be visible on this PR."),
 						Severity: "NORMAL",
 						Anchor: reporter.BitBucketPendingCommentAnchor{
 							DiffType: "EFFECTIVE",
@@ -993,7 +993,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "old text that no longer matches",
+									Text:     reporter.AddPintMarker("old text that no longer matches"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 								},
 								CommentAnchor: reporter.BitBucketCommentAnchor{
@@ -1009,7 +1009,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "comment on same path different line",
+									Text:     reporter.AddPintMarker("comment on same path different line"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 								},
 								CommentAnchor: reporter.BitBucketCommentAnchor{
@@ -1226,7 +1226,7 @@ func TestBitBucketReporter(t *testing.T) {
 									Version:  1,
 									State:    "OPEN",
 									Severity: "NORMAL",
-									Text:     "stale non-blocker with reply",
+									Text:     reporter.AddPintMarker("stale non-blocker with reply"),
 									Author:   reporter.BitBucketCommentAuthor{Name: "user"},
 									Comments: []reporter.BitBucketPullRequestComment{
 										{ID: 701, Text: "reply"},

--- a/internal/reporter/comments.go
+++ b/internal/reporter/comments.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/cloudflare/pint/internal/checks"
 	"github.com/cloudflare/pint/internal/diags"
@@ -531,21 +532,33 @@ Below is the list of checks that were disabled for each Prometheus server define
 	return buf.String()
 }
 
-// pintCommentMarker is appended to general comments pint posts so later runs
-// can recognize them without matching on human-readable text.
+// pintCommentMarker is a hidden HTML comment.
+// We add it to the general comments pint creates so we can tell which comment
+// was created by pint and which by other tools using same API token.
+//
+// We don't add it to review comments because these are matched using
+// 'This pull request was validated by pint' first line.
 const pintCommentMarker = "<!-- pint -->"
 
-func signGeneralComment(body string) string {
-	if body == "" || strings.Contains(body, pintCommentMarker) {
+// addPintMarker adds the marker to the end of the body if needed.
+func addPintMarker(body string) string {
+	if body == "" || hasPintMarker(body) {
 		return body
 	}
-	return strings.TrimRight(body, "\n") + "\n" + pintCommentMarker
+	return body + "\n" + pintCommentMarker
 }
 
-func unsignedGeneralComment(body string) string {
-	return strings.TrimSpace(strings.ReplaceAll(body, pintCommentMarker, ""))
+// removePintMarker removes the marker, and whitespace at the end of the body.
+// It cuts exactly what addPintMarker appends, so the original body is restored.
+func removePintMarker(body string) string {
+	// First trim trailing whitespace so we can match the suffix.
+	body = strings.TrimRightFunc(body, unicode.IsSpace)
+	// Then undo, in reverse order, what addPintMarker appended.
+	return strings.TrimSuffix(strings.TrimSuffix(body, pintCommentMarker), "\n")
 }
 
-func isPintGeneralComment(body string) bool {
+func hasPintMarker(body string) bool {
+	// Marker should be at the end, but the user might edit the message
+	// so we scan the whole comment body just in case.
 	return strings.Contains(body, pintCommentMarker)
 }

--- a/internal/reporter/comments.go
+++ b/internal/reporter/comments.go
@@ -530,3 +530,22 @@ Below is the list of checks that were disabled for each Prometheus server define
 	}
 	return buf.String()
 }
+
+// pintCommentMarker is appended to general comments pint posts so later runs
+// can recognize them without matching on human-readable text.
+const pintCommentMarker = "<!-- pint -->"
+
+func signGeneralComment(body string) string {
+	if body == "" || strings.Contains(body, pintCommentMarker) {
+		return body
+	}
+	return strings.TrimRight(body, "\n") + "\n" + pintCommentMarker
+}
+
+func unsignedGeneralComment(body string) string {
+	return strings.TrimSpace(strings.ReplaceAll(body, pintCommentMarker, ""))
+}
+
+func isPintGeneralComment(body string) bool {
+	return strings.Contains(body, pintCommentMarker)
+}

--- a/internal/reporter/comments.go
+++ b/internal/reporter/comments.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"slices"
 	"strconv"
@@ -37,6 +38,7 @@ type ExistingComment struct {
 	id        string
 	path      string
 	text      string
+	author    string
 	line      int
 	isGeneral bool
 }
@@ -46,6 +48,7 @@ type Commenter interface {
 	Destinations(context.Context) ([]any, error)
 	Summary(context.Context, any, Summary, []PendingComment, []error) error
 	List(context.Context, any) ([]ExistingComment, error)
+	UserID(context.Context, any) (string, error)
 	Create(context.Context, any, PendingComment) error
 	Delete(context.Context, any, ExistingComment) error
 	CanCreate(int) bool
@@ -333,11 +336,43 @@ func Submit(ctx context.Context, s Summary, c Commenter, showDuplicates bool) er
 }
 
 func updateDestination(ctx context.Context, s Summary, c Commenter, dst any, showDuplicates bool) (err error) {
+	slog.LogAttrs(ctx, slog.LevelInfo, "Getting user details", slog.String("reporter", c.Describe()))
+	userID, err := c.UserID(ctx, dst)
+	if err != nil {
+		return fmt.Errorf("failed to get user details: %w", err)
+	}
+
 	slog.LogAttrs(ctx, slog.LevelInfo, "Listing existing comments", slog.String("reporter", c.Describe()))
 	existingComments, err := c.List(ctx, dst)
 	if err != nil {
 		return err
 	}
+
+	// Keep only comments created by pint and remove the marker,
+	// so the text can be compared with pending comments.
+	ownedComments := make([]ExistingComment, 0, len(existingComments))
+	for _, ec := range existingComments {
+		if !hasPintMarker(ec.text) {
+			slog.LogAttrs(
+				ctx, slog.LevelDebug, "Skipping comment not created by pint",
+				slog.String("reporter", c.Describe()),
+				slog.String("id", ec.id),
+			)
+			continue
+		}
+		if userID != "" && ec.author != userID {
+			slog.LogAttrs(
+				ctx, slog.LevelDebug, "Skipping comment from another user",
+				slog.String("reporter", c.Describe()),
+				slog.String("id", ec.id),
+				slog.String("author", ec.author),
+			)
+			continue
+		}
+		ec.text = removePintMarker(ec.text)
+		ownedComments = append(ownedComments, ec)
+	}
+	existingComments = ownedComments
 
 	var created int
 	var errs []error
@@ -384,6 +419,8 @@ func updateDestination(ctx context.Context, s Summary, c Commenter, dst any, sho
 			slog.String("path", pending.path),
 			slog.Int("line", pending.line),
 		)
+		// Add the comment marker, existing comments are stored without the marker.
+		pending.text = AddPintMarker(pending.text)
 		if err := c.Create(ctx, dst, pending); err != nil {
 			slog.LogAttrs(
 				ctx, slog.LevelError, "Failed to create a new comment",
@@ -540,8 +577,8 @@ Below is the list of checks that were disabled for each Prometheus server define
 // 'This pull request was validated by pint' first line.
 const pintCommentMarker = "<!-- pint -->"
 
-// addPintMarker adds the marker to the end of the body if needed.
-func addPintMarker(body string) string {
+// AddPintMarker adds the marker to the end of the body if needed.
+func AddPintMarker(body string) string {
 	if body == "" || hasPintMarker(body) {
 		return body
 	}
@@ -549,11 +586,11 @@ func addPintMarker(body string) string {
 }
 
 // removePintMarker removes the marker, and whitespace at the end of the body.
-// It cuts exactly what addPintMarker appends, so the original body is restored.
+// It cuts exactly what AddPintMarker appends, so the original body is restored.
 func removePintMarker(body string) string {
 	// First trim trailing whitespace so we can match the suffix.
 	body = strings.TrimRightFunc(body, unicode.IsSpace)
-	// Then undo, in reverse order, what addPintMarker appended.
+	// Then undo, in reverse order, what AddPintMarker appended.
 	return strings.TrimSuffix(strings.TrimSuffix(body, pintCommentMarker), "\n")
 }
 

--- a/internal/reporter/comments_test.go
+++ b/internal/reporter/comments_test.go
@@ -996,6 +996,15 @@ foo details
 	}
 }
 
+func TestIsPintGeneralComment(t *testing.T) {
+	quoted := "> " + tooManyCommentsMsg(3, 1)
+	require.False(t, isPintGeneralComment(tooManyCommentsMsg(3, 1)))
+	require.False(t, isPintGeneralComment(quoted))
+	require.True(t, isPintGeneralComment(signGeneralComment(tooManyCommentsMsg(3, 1))))
+	require.False(t, isPintGeneralComment(signGeneralComment("")))
+	require.Equal(t, tooManyCommentsMsg(3, 1), unsignedGeneralComment(signGeneralComment(tooManyCommentsMsg(3, 1))))
+}
+
 func TestCommentsCommonPaths(t *testing.T) {
 	type errorCheck func(err error) error
 

--- a/internal/reporter/comments_test.go
+++ b/internal/reporter/comments_test.go
@@ -996,13 +996,128 @@ foo details
 	}
 }
 
-func TestIsPintGeneralComment(t *testing.T) {
-	quoted := "> " + tooManyCommentsMsg(3, 1)
-	require.False(t, isPintGeneralComment(tooManyCommentsMsg(3, 1)))
-	require.False(t, isPintGeneralComment(quoted))
-	require.True(t, isPintGeneralComment(signGeneralComment(tooManyCommentsMsg(3, 1))))
-	require.False(t, isPintGeneralComment(signGeneralComment("")))
-	require.Equal(t, tooManyCommentsMsg(3, 1), unsignedGeneralComment(signGeneralComment(tooManyCommentsMsg(3, 1))))
+func TestPintMarker(t *testing.T) {
+	msg := tooManyCommentsMsg(3, 1)
+
+	t.Run("has marker", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			body     string
+			expected bool
+		}{
+			{
+				name:     "message without the marker",
+				body:     msg,
+				expected: false,
+			},
+			{
+				name:     "quoted message without the marker",
+				body:     "> " + msg,
+				expected: false,
+			},
+			{
+				name:     "message with the marker",
+				body:     msg + "\n" + pintCommentMarker,
+				expected: true,
+			},
+			{
+				name:     "empty body",
+				body:     "",
+				expected: false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				require.Equal(t, tc.expected, hasPintMarker(tc.body))
+			})
+		}
+	})
+
+	t.Run("add marker", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			body     string
+			expected string
+		}{
+			{
+				name:     "empty body stays empty",
+				body:     "",
+				expected: "",
+			},
+			{
+				name:     "body with the marker is unchanged",
+				body:     msg + "\n" + pintCommentMarker,
+				expected: msg + "\n" + pintCommentMarker,
+			},
+			{
+				name:     "body gets the marker at the end",
+				body:     msg,
+				expected: msg + "\n" + pintCommentMarker,
+			},
+			{
+				name:     "trailing newlines are kept",
+				body:     msg + "\n\n",
+				expected: msg + "\n\n\n" + pintCommentMarker,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				require.Equal(t, tc.expected, addPintMarker(tc.body))
+			})
+		}
+	})
+
+	t.Run("remove marker", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			body     string
+			expected string
+		}{
+			{
+				name:     "signed body returns the original message",
+				body:     msg + "\n" + pintCommentMarker,
+				expected: msg,
+			},
+			{
+				name:     "signed body with trailing newline returns the original message",
+				body:     msg + "\n\n" + pintCommentMarker,
+				expected: msg + "\n",
+			},
+			{
+				name:     "whitespace after the marker is removed",
+				body:     msg + "\n" + pintCommentMarker + "  \n",
+				expected: msg,
+			},
+			{
+				name:     "trailing whitespace without the marker is removed",
+				body:     msg + "  ",
+				expected: msg,
+			},
+			{
+				name:     "leading whitespace is kept",
+				body:     "  " + msg,
+				expected: "  " + msg,
+			},
+			{
+				name:     "body with only the marker is removed",
+				body:     pintCommentMarker,
+				expected: "",
+			},
+			{
+				name:     "empty body stays empty",
+				body:     "",
+				expected: "",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				require.Equal(t, tc.expected, removePintMarker(tc.body))
+			})
+		}
+	})
 }
 
 func TestCommentsCommonPaths(t *testing.T) {

--- a/internal/reporter/comments_test.go
+++ b/internal/reporter/comments_test.go
@@ -33,6 +33,7 @@ type testCommenter struct {
 	destinations func(context.Context) ([]any, error)
 	summary      func(context.Context, any, Summary, []PendingComment, []error) error
 	list         func(context.Context, any) ([]ExistingComment, error)
+	userID       func(context.Context, any) (string, error)
 	create       func(context.Context, any, PendingComment) error
 	delete       func(context.Context, any, ExistingComment) error
 	canCreate    func(int) bool
@@ -53,6 +54,13 @@ func (tc testCommenter) Summary(ctx context.Context, dst any, s Summary, comment
 
 func (tc testCommenter) List(ctx context.Context, dst any) ([]ExistingComment, error) {
 	return tc.list(ctx, dst)
+}
+
+func (tc testCommenter) UserID(ctx context.Context, dst any) (string, error) {
+	if tc.userID != nil {
+		return tc.userID(ctx, dst)
+	}
+	return "", nil
 }
 
 func (tc testCommenter) Create(ctx context.Context, dst any, comment PendingComment) error {
@@ -108,9 +116,10 @@ func TestCommenter(t *testing.T) {
 		},
 	}
 	fooComment := ExistingComment{
-		path: "foo.txt",
-		line: 2,
-		text: `:stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **foo** check.
+		path:   "foo.txt",
+		line:   2,
+		author: "pint",
+		text: AddPintMarker(`:stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **foo** check.
 
 ------
 
@@ -124,7 +133,7 @@ foo details
 ------
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).
-`,
+`),
 		meta: nil,
 	}
 
@@ -148,9 +157,10 @@ foo details
 		},
 	}
 	barComment := ExistingComment{
-		path: "bar.txt",
-		line: 1,
-		text: `:warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **bar** check.
+		path:   "bar.txt",
+		line:   1,
+		author: "pint",
+		text: AddPintMarker(`:warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **bar** check.
 
 ------
 
@@ -159,7 +169,7 @@ bar warning
 ------
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/bar.html).
-`,
+`),
 		meta: nil,
 	}
 
@@ -218,10 +228,54 @@ bar warning
 					}
 					return nil
 				},
+				userID: func(_ context.Context, _ any) (string, error) {
+					return "pint", nil
+				},
 				list: func(_ context.Context, _ any) ([]ExistingComment, error) {
 					return []ExistingComment{fooComment, barComment}, nil
 				},
 				create: func(_ context.Context, _ any, p PendingComment) error {
+					return fmt.Errorf("shouldn't try to create %s:%d", p.path, p.line)
+				},
+				delete: func(_ context.Context, _ any, e ExistingComment) error {
+					return fmt.Errorf("shouldn't try to delete %s:%d", e.path, e.line)
+				},
+				isEqual: func(e ExistingComment, p PendingComment) bool {
+					return e.path == p.path && e.line == p.line && e.text == p.text
+				},
+				canCreate: func(_ int) bool {
+					return true
+				},
+			},
+			checkErr: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			description: "recreates a comment that belongs to another user",
+			reports:     []Report{fooReport},
+			commenter: testCommenter{
+				destinations: func(_ context.Context) ([]any, error) {
+					return []any{1}, nil
+				},
+				summary: func(_ context.Context, _ any, _ Summary, _ []PendingComment, errs []error) error {
+					if len(errs) != 0 {
+						return fmt.Errorf("Expected empty errs, got %v", errs)
+					}
+					return nil
+				},
+				userID: func(_ context.Context, _ any) (string, error) {
+					return "pint", nil
+				},
+				list: func(_ context.Context, _ any) ([]ExistingComment, error) {
+					comment := fooComment
+					comment.author = "someone-else"
+					return []ExistingComment{comment}, nil
+				},
+				create: func(_ context.Context, _ any, p PendingComment) error {
+					if p.path == fooComment.path && p.line == fooComment.line && p.text == fooComment.text {
+						return nil
+					}
 					return fmt.Errorf("shouldn't try to create %s:%d", p.path, p.line)
 				},
 				delete: func(_ context.Context, _ any, e ExistingComment) error {
@@ -485,7 +539,7 @@ foo details
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).
 `
-					if p.text != expected {
+					if p.text != AddPintMarker(expected) {
 						return fmt.Errorf("wrong text: %s", cmp.Diff(expected, p.text))
 					}
 					return nil
@@ -569,7 +623,7 @@ foo details
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).
 `
-					if p.text != expected {
+					if p.text != AddPintMarker(expected) {
 						return fmt.Errorf("wrong text: %s", cmp.Diff(expected, p.text))
 					}
 					return nil
@@ -725,7 +779,7 @@ foo details
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).
 `
-					if p.line == 3 && p.text != expected {
+					if p.line == 3 && p.text != AddPintMarker(expected) {
 						return fmt.Errorf("wrong text on first report: %s", cmp.Diff(expected, p.text))
 					}
 					expected2 := `:stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **foo** check.
@@ -743,7 +797,7 @@ foo details
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).
 `
-					if p.line == 2 && p.text != expected2 {
+					if p.line == 2 && p.text != AddPintMarker(expected2) {
 						return fmt.Errorf("wrong text on second report: %s", cmp.Diff(expected2, p.text))
 					}
 					return nil
@@ -940,7 +994,7 @@ foo details
 						fooComment,
 						{
 							path:      "",
-							text:      "stale general comment",
+							text:      AddPintMarker("stale general comment"),
 							line:      0,
 							meta:      nil,
 							isGeneral: true,
@@ -1064,7 +1118,7 @@ func TestPintMarker(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				require.Equal(t, tc.expected, addPintMarker(tc.body))
+				require.Equal(t, tc.expected, AddPintMarker(tc.body))
 			})
 		}
 	})

--- a/internal/reporter/github.go
+++ b/internal/reporter/github.go
@@ -146,9 +146,37 @@ func (gr GithubReporter) Summary(ctx context.Context, _ any, s Summary, pendingC
 	return nil
 }
 
+func (gr GithubReporter) getUserID(ctx context.Context) (int64, error) {
+	slog.LogAttrs(ctx, slog.LevelDebug, "Getting current GitHub user details")
+	reqCtx, cancel := gr.reqContext(ctx)
+	defer cancel()
+	user, _, err := gr.client.Users.Get(reqCtx, "")
+	if err != nil {
+		return 0, err
+	}
+	return user.GetID(), nil
+}
+
+func ownGitHubIssueComment(userID int64, ic *github.IssueComment) bool {
+	if !isPintGeneralComment(ic.GetBody()) {
+		return false
+	}
+	if userID == 0 {
+		return true
+	}
+	return ic.GetUser().GetID() == userID
+}
+
 func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, error) {
 	reqCtx, cancel := gr.reqContext(ctx)
 	defer cancel()
+
+	userID, err := gr.getUserID(ctx)
+	if err != nil {
+		// Fall back to the comment marker so we never treat other issue
+		// comments as ours when the token cannot identify the current user.
+		slog.LogAttrs(ctx, slog.LevelWarn, "Failed to get authenticated GitHub user, will only delete general comments posted by pint", slog.Any("err", err))
+	}
 
 	slog.LogAttrs(ctx, slog.LevelDebug, "Getting the list of pull request comments", slog.Int("pr", gr.prNum))
 	existing, _, err := gr.client.PullRequests.ListComments(reqCtx, gr.owner, gr.repo, gr.prNum, nil)
@@ -177,10 +205,18 @@ func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, er
 		return nil, fmt.Errorf("failed to list issue comments: %w", err)
 	}
 	for _, ic := range issueComments {
+		if !ownGitHubIssueComment(userID, ic) {
+			slog.LogAttrs(
+				ctx, slog.LevelDebug, "Skipping issue comment from another user",
+				slog.Int64("id", ic.GetID()),
+				slog.String("user", ic.GetUser().GetLogin()),
+			)
+			continue
+		}
 		comments = append(comments, ExistingComment{
 			id:        strconv.FormatInt(ic.GetID(), 10),
 			path:      "",
-			text:      ic.GetBody(),
+			text:      unsignedGeneralComment(ic.GetBody()),
 			line:      0,
 			meta:      ghIssueCommentMeta{id: ic.GetID()},
 			isGeneral: true,
@@ -404,6 +440,7 @@ func formatGHReviewBody(ctx context.Context, version string, summary Summary, sh
 }
 
 func (gr GithubReporter) generalComment(ctx context.Context, body string) error {
+	body = signGeneralComment(body)
 	comment := github.IssueComment{
 		Body: new(body),
 	}

--- a/internal/reporter/github.go
+++ b/internal/reporter/github.go
@@ -158,7 +158,7 @@ func (gr GithubReporter) getUserID(ctx context.Context) (int64, error) {
 }
 
 func ownGitHubIssueComment(userID int64, ic *github.IssueComment) bool {
-	if !isPintGeneralComment(ic.GetBody()) {
+	if !hasPintMarker(ic.GetBody()) {
 		return false
 	}
 	if userID == 0 {
@@ -168,15 +168,15 @@ func ownGitHubIssueComment(userID int64, ic *github.IssueComment) bool {
 }
 
 func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, error) {
-	reqCtx, cancel := gr.reqContext(ctx)
-	defer cancel()
-
 	userID, err := gr.getUserID(ctx)
 	if err != nil {
 		// Fall back to the comment marker so we never treat other issue
 		// comments as ours when the token cannot identify the current user.
 		slog.LogAttrs(ctx, slog.LevelWarn, "Failed to get authenticated GitHub user, will only delete general comments posted by pint", slog.Any("err", err))
 	}
+
+	reqCtx, cancel := gr.reqContext(ctx)
+	defer cancel()
 
 	slog.LogAttrs(ctx, slog.LevelDebug, "Getting the list of pull request comments", slog.Int("pr", gr.prNum))
 	existing, _, err := gr.client.PullRequests.ListComments(reqCtx, gr.owner, gr.repo, gr.prNum, nil)
@@ -216,7 +216,7 @@ func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, er
 		comments = append(comments, ExistingComment{
 			id:        strconv.FormatInt(ic.GetID(), 10),
 			path:      "",
-			text:      unsignedGeneralComment(ic.GetBody()),
+			text:      removePintMarker(ic.GetBody()),
 			line:      0,
 			meta:      ghIssueCommentMeta{id: ic.GetID()},
 			isGeneral: true,
@@ -440,7 +440,7 @@ func formatGHReviewBody(ctx context.Context, version string, summary Summary, sh
 }
 
 func (gr GithubReporter) generalComment(ctx context.Context, body string) error {
-	body = signGeneralComment(body)
+	body = addPintMarker(body)
 	comment := github.IssueComment{
 		Body: new(body),
 	}

--- a/internal/reporter/github.go
+++ b/internal/reporter/github.go
@@ -146,35 +146,18 @@ func (gr GithubReporter) Summary(ctx context.Context, _ any, s Summary, pendingC
 	return nil
 }
 
-func (gr GithubReporter) getUserID(ctx context.Context) (int64, error) {
+func (gr GithubReporter) UserID(ctx context.Context, _ any) (string, error) {
 	slog.LogAttrs(ctx, slog.LevelDebug, "Getting current GitHub user details")
 	reqCtx, cancel := gr.reqContext(ctx)
 	defer cancel()
 	user, _, err := gr.client.Users.Get(reqCtx, "")
 	if err != nil {
-		return 0, err
+		return "", err
 	}
-	return user.GetID(), nil
-}
-
-func ownGitHubIssueComment(userID int64, ic *github.IssueComment) bool {
-	if !hasPintMarker(ic.GetBody()) {
-		return false
-	}
-	if userID == 0 {
-		return true
-	}
-	return ic.GetUser().GetID() == userID
+	return strconv.FormatInt(user.GetID(), 10), nil
 }
 
 func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, error) {
-	userID, err := gr.getUserID(ctx)
-	if err != nil {
-		// Fall back to the comment marker so we never treat other issue
-		// comments as ours when the token cannot identify the current user.
-		slog.LogAttrs(ctx, slog.LevelWarn, "Failed to get authenticated GitHub user, will only delete general comments posted by pint", slog.Any("err", err))
-	}
-
 	reqCtx, cancel := gr.reqContext(ctx)
 	defer cancel()
 
@@ -194,6 +177,7 @@ func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, er
 			id:        strconv.FormatInt(ec.GetID(), 10),
 			path:      ec.GetPath(),
 			text:      ec.GetBody(),
+			author:    strconv.FormatInt(ec.GetUser().GetID(), 10),
 			line:      ec.GetLine(),
 			meta:      ghCommentMeta{id: ec.GetID()},
 			isGeneral: false,
@@ -205,18 +189,11 @@ func (gr GithubReporter) List(ctx context.Context, _ any) ([]ExistingComment, er
 		return nil, fmt.Errorf("failed to list issue comments: %w", err)
 	}
 	for _, ic := range issueComments {
-		if !ownGitHubIssueComment(userID, ic) {
-			slog.LogAttrs(
-				ctx, slog.LevelDebug, "Skipping issue comment from another user",
-				slog.Int64("id", ic.GetID()),
-				slog.String("user", ic.GetUser().GetLogin()),
-			)
-			continue
-		}
 		comments = append(comments, ExistingComment{
 			id:        strconv.FormatInt(ic.GetID(), 10),
 			path:      "",
-			text:      removePintMarker(ic.GetBody()),
+			text:      ic.GetBody(),
+			author:    strconv.FormatInt(ic.GetUser().GetID(), 10),
 			line:      0,
 			meta:      ghIssueCommentMeta{id: ic.GetID()},
 			isGeneral: true,
@@ -440,7 +417,7 @@ func formatGHReviewBody(ctx context.Context, version string, summary Summary, sh
 }
 
 func (gr GithubReporter) generalComment(ctx context.Context, body string) error {
-	body = addPintMarker(body)
+	body = AddPintMarker(body)
 	comment := github.IssueComment{
 		Body: new(body),
 	}

--- a/internal/reporter/github_internal_test.go
+++ b/internal/reporter/github_internal_test.go
@@ -7,9 +7,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-github/v88/github"
 	"github.com/neilotoole/slogt/v2"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOwnGitHubIssueComment(t *testing.T) {
+	pintBody := signGeneralComment(tooManyCommentsMsg(3, 1))
+	quoted := "> " + tooManyCommentsMsg(3, 1)
+	author := github.User{ID: new(int64(42)), Login: new("ci-user")}
+	other := github.User{ID: new(int64(99)), Login: new("reviewer")}
+
+	require.True(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new(pintBody), User: &author}))
+	require.False(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new(pintBody), User: &other}))
+	require.False(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new(quoted), User: &author}))
+	require.False(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new("LGTM"), User: &author}))
+	require.True(t, ownGitHubIssueComment(0, &github.IssueComment{Body: new(pintBody), User: &other}))
+	require.False(t, ownGitHubIssueComment(0, &github.IssueComment{Body: new("workflow status comment"), User: &author}))
+}
 
 func TestGithubReporterDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/reporter/github_internal_test.go
+++ b/internal/reporter/github_internal_test.go
@@ -7,24 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
 	"github.com/neilotoole/slogt/v2"
 	"github.com/stretchr/testify/require"
 )
-
-func TestOwnGitHubIssueComment(t *testing.T) {
-	pintBody := addPintMarker(tooManyCommentsMsg(3, 1))
-	quoted := "> " + tooManyCommentsMsg(3, 1)
-	author := github.User{ID: new(int64(42)), Login: new("ci-user")}
-	other := github.User{ID: new(int64(99)), Login: new("reviewer")}
-
-	require.True(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new(pintBody), User: &author}))
-	require.False(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new(pintBody), User: &other}))
-	require.False(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new(quoted), User: &author}))
-	require.False(t, ownGitHubIssueComment(42, &github.IssueComment{Body: new("LGTM"), User: &author}))
-	require.True(t, ownGitHubIssueComment(0, &github.IssueComment{Body: new(pintBody), User: &other}))
-	require.False(t, ownGitHubIssueComment(0, &github.IssueComment{Body: new("workflow status comment"), User: &author}))
-}
 
 func TestGithubReporterDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/reporter/github_internal_test.go
+++ b/internal/reporter/github_internal_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestOwnGitHubIssueComment(t *testing.T) {
-	pintBody := signGeneralComment(tooManyCommentsMsg(3, 1))
+	pintBody := addPintMarker(tooManyCommentsMsg(3, 1))
 	quoted := "> " + tooManyCommentsMsg(3, 1)
 	author := github.User{ID: new(int64(42)), Login: new("ci-user")}
 	other := github.User{ID: new(int64(99)), Login: new("reviewer")}

--- a/internal/reporter/github_test.go
+++ b/internal/reporter/github_test.go
@@ -248,7 +248,7 @@ func TestGitHubReporter(t *testing.T) {
 					return
 				}
 				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/issues/123/comments" {
-					_, _ = w.Write([]byte(`[{"id":999,"body":"This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR."}]`))
+					_, _ = w.Write([]byte(`[{"id":999,"body":"This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR.\n<!-- pint -->"}]`))
 					return
 				}
 				if r.Method == http.MethodDelete && r.URL.Path == "/api/v3/repos/foo/bar/issues/comments/999" {
@@ -308,7 +308,7 @@ func TestGitHubReporter(t *testing.T) {
 					return
 				}
 				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/issues/123/comments" {
-					_, _ = w.Write([]byte(`[{"id":999,"body":"This pint run would create 2 comment(s), which is more than the limit configured for pint (1).\n1 comment(s) were skipped and won't be visible on this PR."}]`))
+					_, _ = w.Write([]byte(`[{"id":999,"body":"This pint run would create 2 comment(s), which is more than the limit configured for pint (1).\n1 comment(s) were skipped and won't be visible on this PR.\n<!-- pint -->"}]`))
 					return
 				}
 				if r.Method == http.MethodDelete && r.URL.Path == "/api/v3/repos/foo/bar/issues/comments/999" {
@@ -365,6 +365,86 @@ func TestGitHubReporter(t *testing.T) {
 					},
 				},
 			}),
+		},
+		{
+			description: "foreign general comments are not deleted",
+			owner:       "foo",
+			repo:        "bar",
+			token:       "something",
+			prNum:       123,
+			maxComments: 50,
+			timeout:     time.Second,
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/user" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"id":42,"login":"ci-user"}`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/reviews" {
+					_, _ = w.Write([]byte(`[{"id":1,"body":"### This pull request was validated by [pint](https://github.com/cloudflare/pint).\nxxxx"}]`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
+					_, _ = w.Write([]byte(`[]`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/issues/123/comments" {
+					_, _ = w.Write([]byte(`[
+						{"id":100,"body":"LGTM","user":{"id":7,"login":"reviewer"}},
+						{"id":101,"body":"automated review comment","user":{"id":8,"login":"review-bot"}},
+						{"id":102,"body":"workflow status comment","user":{"id":9,"login":"workflow-bot"}},
+						{"id":103,"body":"> This pint run would create 3 comment(s), which is more than the limit configured for pint (1).","user":{"id":42,"login":"ci-user"}}
+					]`))
+					return
+				}
+				if r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v3/repos/foo/bar/issues/comments/") {
+					t.Errorf("Unexpected delete of foreign general comment: %s", r.URL.Path)
+					return
+				}
+				_, _ = w.Write([]byte(""))
+			}),
+			summary: reporter.NewSummary([]reporter.Report{}),
+		},
+		{
+			description: "same-author non-pint comment is not deleted",
+			owner:       "foo",
+			repo:        "bar",
+			token:       "something",
+			prNum:       123,
+			maxComments: 50,
+			timeout:     time.Second,
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/user" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"id":42,"login":"ci-user"}`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/reviews" {
+					_, _ = w.Write([]byte(`[{"id":1,"body":"### This pull request was validated by [pint](https://github.com/cloudflare/pint).\nxxxx"}]`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
+					_, _ = w.Write([]byte(`[]`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/issues/123/comments" {
+					_, _ = w.Write([]byte(`[
+						{"id":200,"body":"workflow status comment","user":{"id":42,"login":"ci-user"}},
+						{"id":201,"body":"This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR.\n<!-- pint -->","user":{"id":42,"login":"ci-user"}}
+					]`))
+					return
+				}
+				if r.Method == http.MethodDelete && r.URL.Path == "/api/v3/repos/foo/bar/issues/comments/200" {
+					t.Errorf("Unexpected delete of non-pint workflow comment")
+					return
+				}
+				if r.Method == http.MethodDelete && r.URL.Path == "/api/v3/repos/foo/bar/issues/comments/201" {
+					_, _ = w.Write([]byte(`{}`))
+					return
+				}
+				_, _ = w.Write([]byte(""))
+			}),
+			summary: reporter.NewSummary([]reporter.Report{}),
 		},
 		{
 			description: "error crating review",
@@ -643,7 +723,7 @@ func TestGitHubReporter(t *testing.T) {
 				if r.Method == http.MethodPost && r.URL.Path == "/api/v3/repos/foo/bar/issues/123/comments" {
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
-					if b == `{"body":"This pint run would create 4 comment(s), which is more than the limit configured for pint (2).\n2 comment(s) were skipped and won't be visible on this PR."}` {
+					if b == `{"body":"This pint run would create 4 comment(s), which is more than the limit configured for pint (2).\n2 comment(s) were skipped and won't be visible on this PR.\n<!-- pint -->"}` {
 						w.WriteHeader(http.StatusInternalServerError)
 						_, _ = w.Write([]byte("Cannot create issue comment"))
 						return
@@ -1596,17 +1676,26 @@ func TestNewGithubReporterEnterpriseURLError(t *testing.T) {
 
 func TestGithubReporterListSkipsGeneralComments(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v3/repos/owner/repo/pulls/123/comments" {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/user":
+			_, _ = w.Write([]byte(`{"id":42,"login":"ci-user"}`))
+		case "/api/v3/repos/owner/repo/pulls/123/comments":
 			// Return a mix of file comments and general comments (empty path)
-			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`[
 				{"id": 1, "path": "file.yml", "body": "file comment", "line": 10},
 				{"id": 2, "path": "", "body": "general comment", "line": 0},
 				{"id": 3, "path": "other.yml", "body": "another file comment", "line": 5}
 			]`))
-			return
+		case "/api/v3/repos/owner/repo/issues/123/comments":
+			_, _ = w.Write([]byte(`[
+				{"id": 10, "body": "LGTM", "user": {"id": 7, "login": "reviewer"}},
+				{"id": 11, "body": "> This pint run would create 3 comment(s), which is more than the limit configured for pint (1).", "user": {"id": 42, "login": "ci-user"}},
+				{"id": 12, "body": "This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR.\n<!-- pint -->", "user": {"id": 42, "login": "ci-user"}}
+			]`))
+		default:
+			w.WriteHeader(http.StatusOK)
 		}
-		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
@@ -1629,6 +1718,7 @@ func TestGithubReporterListSkipsGeneralComments(t *testing.T) {
 
 	comments, err := r.List(t.Context(), nil)
 	require.NoError(t, err)
-	// Should only have 2 comments (general comment with empty path skipped)
-	require.Len(t, comments, 2)
+	// Two file comments plus pint's own signed general comment. Empty-path
+	// review comments, reviewer comments, and unsigned quotes are skipped.
+	require.Len(t, comments, 3)
 }

--- a/internal/reporter/github_test.go
+++ b/internal/reporter/github_test.go
@@ -55,7 +55,7 @@ func TestGitHubReporter(t *testing.T) {
 
 	for _, tc := range []testCaseT{
 		{
-			description: "list pull reviews timeout",
+			description: "get user details timeout",
 			owner:       "foo",
 			repo:        "bar",
 			token:       "something",
@@ -67,7 +67,7 @@ func TestGitHubReporter(t *testing.T) {
 			}),
 			timeout: 100 * time.Millisecond,
 			error: func(_ string) string {
-				return "failed to list pull request reviews: context deadline exceeded"
+				return "failed to get user details: context deadline exceeded"
 			},
 			summary: reporter.NewSummary([]reporter.Report{
 				{
@@ -603,8 +603,8 @@ func TestGitHubReporter(t *testing.T) {
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
 					switch b {
-					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock1** check.\n\n------\n\nsyntax error1\n\n<details>\n<summary>More information</summary>\nsyntax details1\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock1.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
-					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock2** check.\n\n------\n\nsyntax error2\n\n<details>\n<summary>More information</summary>\nsyntax details2\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock2.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock1** check.\n\n------\n\nsyntax error1\n\n<details>\n<summary>More information</summary>\nsyntax details1\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock1.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock2** check.\n\n------\n\nsyntax error2\n\n<details>\n<summary>More information</summary>\nsyntax details2\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock2.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
 					case `{"body":"This pint run would create 4 comment(s), which is more than 2 limit configured for pint.\n2 comments were skipped and won't be visible on this PR."}`:
 					default:
 						t.Errorf("Unexpected comment: %s", b)
@@ -960,7 +960,63 @@ func TestGitHubReporter(t *testing.T) {
 				if r.Method == http.MethodPost && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
-					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":1,"side":"RIGHT","commit_id":"HEAD"}` {
+					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":1,"side":"RIGHT","commit_id":"HEAD"}` {
+						t.Errorf("Unexpected comment: %s", b)
+						t.FailNow()
+					}
+				}
+				_, _ = w.Write([]byte(""))
+			}),
+			summary: reporter.NewSummary([]reporter.Report{
+				{
+					Path: discovery.Path{
+						Name:          "foo.txt",
+						SymlinkTarget: "foo.txt",
+					},
+
+					Changes: &discovery.Changes{
+						OldPath: "",
+						Lines:   git.LineNumbers{{Before: 0, After: 1, Modified: true}},
+					},
+					Rule: mockFile.Groups[0].Rules[0],
+					Problem: checks.Problem{
+						Lines: diags.LineRange{
+							First: 1,
+							Last:  1,
+						},
+						Reporter: "mock",
+						Summary:  "syntax error",
+						Details:  "syntax details",
+						Severity: checks.Fatal,
+					},
+				},
+			}),
+		},
+		{
+			description: "stale inline comment is kept",
+			owner:       "foo",
+			repo:        "bar",
+			token:       "something",
+			prNum:       123,
+			maxComments: 50,
+			timeout:     time.Second,
+			httpHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/user" {
+					_, _ = w.Write([]byte(`{"id":42,"login":"ci-user"}`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/reviews" {
+					_, _ = w.Write([]byte(`[]`))
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
+					_, _ = w.Write([]byte(`[{"id":1,"commit_id":"fake-commit-id","path":"foo.txt","line":2,"body":"stale comment\n<!-- pint -->","user":{"id":42,"login":"ci-user"}}]`))
+					return
+				}
+				if r.Method == http.MethodPost && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
+					body, _ := io.ReadAll(r.Body)
+					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
+					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":1,"side":"RIGHT","commit_id":"HEAD"}` {
 						t.Errorf("Unexpected comment: %s", b)
 						t.FailNow()
 					}
@@ -1012,7 +1068,7 @@ func TestGitHubReporter(t *testing.T) {
 				if r.Method == http.MethodPost && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
-					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}` {
+					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}` {
 						t.Errorf("Unexpected comment: %s", b)
 						t.FailNow()
 					}
@@ -1064,7 +1120,7 @@ func TestGitHubReporter(t *testing.T) {
 				if r.Method == http.MethodPost && r.URL.Path == "/api/v3/repos/foo/bar/pulls/123/comments" {
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
-					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":3,"side":"LEFT","commit_id":"HEAD"}` {
+					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":3,"side":"LEFT","commit_id":"HEAD"}` {
 						t.Errorf("Unexpected comment: %s", b)
 						t.FailNow()
 					}
@@ -1119,7 +1175,7 @@ func TestGitHubReporter(t *testing.T) {
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
 					// Problem on old line 3, but only old line 5 is in the diff.
 					// Moved to nearest deleted line: 5.
-					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":5,"side":"LEFT","commit_id":"HEAD"}` {
+					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":5,"side":"LEFT","commit_id":"HEAD"}` {
 						t.Errorf("Unexpected comment: %s", b)
 						t.FailNow()
 					}
@@ -1174,7 +1230,7 @@ func TestGitHubReporter(t *testing.T) {
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
 					// Diff only has added lines, no deleted lines to attach to.
 					// Falls through to RIGHT side, moved to nearest added line: 5.
-					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":5,"side":"RIGHT","commit_id":"HEAD"}` {
+					if b != `{"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":5,"side":"RIGHT","commit_id":"HEAD"}` {
 						t.Errorf("Unexpected comment: %s", b)
 						t.FailNow()
 					}
@@ -1377,10 +1433,10 @@ Below is the list of checks that were disabled for each Prometheus server define
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
 					switch b {
-					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
-					case `{"body":":warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **different** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/different.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
-					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":4,"side":"RIGHT","commit_id":"HEAD"}`:
-					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":5,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **different** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/different.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":4,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":5,"side":"RIGHT","commit_id":"HEAD"}`:
 					default:
 						t.Errorf("Unexpected comment: %s", b)
 					}
@@ -1499,8 +1555,8 @@ Below is the list of checks that were disabled for each Prometheus server define
 					body, _ := io.ReadAll(r.Body)
 					b := strings.TrimSpace(strings.TrimRight(string(body), "\n\t\r"))
 					switch b {
-					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\nThe same issue was reported 2 more time(s), duplicates were suppressed.\n\n<details>\n<summary>Show affected rules</summary>\n\n- ` + "`sum errors` at `foo.txt:4`" + `\n` + "- `sum errors` at `foo.txt:5`" + `\n\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
-					case `{"body":":warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **different** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/different.html).\n","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":stop_sign: **Bug** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\nThe same issue was reported 2 more time(s), duplicates were suppressed.\n\n<details>\n<summary>Show affected rules</summary>\n\n- ` + "`sum errors` at `foo.txt:4`" + `\n` + "- `sum errors` at `foo.txt:5`" + `\n\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
+					case `{"body":":warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **different** check.\n\n------\n\nsyntax error\n\n<details>\n<summary>More information</summary>\nsyntax details\n</details>\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/different.html).\n\n<!-- pint -->","path":"foo.txt","line":2,"side":"RIGHT","commit_id":"HEAD"}`:
 					default:
 						t.Errorf("Unexpected comment: %s", b)
 					}
@@ -1718,7 +1774,7 @@ func TestGithubReporterListSkipsGeneralComments(t *testing.T) {
 
 	comments, err := r.List(t.Context(), nil)
 	require.NoError(t, err)
-	// Two file comments plus pint's own signed general comment. Empty-path
-	// review comments, reviewer comments, and unsigned quotes are skipped.
-	require.Len(t, comments, 3)
+	// List returns all comments as is, only the empty path PR comment is
+	// skipped. Ownership filtering happens in the shared submit flow.
+	require.Len(t, comments, 5)
 }

--- a/internal/reporter/gitlab.go
+++ b/internal/reporter/gitlab.go
@@ -163,6 +163,10 @@ func (gl GitLabReporter) Summary(ctx context.Context, dst any, s Summary, pendin
 	return nil
 }
 
+func (gl GitLabReporter) UserID(_ context.Context, dst any) (string, error) {
+	return strconv.FormatInt(dst.(gitlabMR).userID, 10), nil
+}
+
 func (gl GitLabReporter) List(_ context.Context, dst any) ([]ExistingComment, error) {
 	mr := dst.(gitlabMR)
 	comments := make([]ExistingComment, 0, len(mr.discussions))
@@ -178,10 +182,11 @@ func (gl GitLabReporter) List(_ context.Context, dst any) ([]ExistingComment, er
 			if note.Position == nil {
 				// General comment, no path, line or commit information available.
 				comments = append(comments, ExistingComment{
-					id:   strconv.FormatInt(note.ID, 10),
-					path: "",
-					text: note.Body,
-					line: 0,
+					id:     strconv.FormatInt(note.ID, 10),
+					path:   "",
+					text:   note.Body,
+					author: strconv.FormatInt(note.Author.ID, 10),
+					line:   0,
 					meta: gitlabComment{
 						discussionID: disc.ID,
 						noteID:       note.ID,
@@ -346,10 +351,13 @@ func (gl GitLabReporter) generalComment(ctx context.Context, mr gitlabMR, msg st
 			if note.Author.ID != mr.userID {
 				continue
 			}
+			if !hasPintMarker(note.Body) {
+				continue
+			}
 			if note.Position != nil {
 				continue
 			}
-			if note.Body == msg {
+			if removePintMarker(note.Body) == msg {
 				slog.LogAttrs(ctx, slog.LevelDebug, "Comment already exits", slog.String("body", msg))
 				return nil
 			}
@@ -358,7 +366,7 @@ func (gl GitLabReporter) generalComment(ctx context.Context, mr gitlabMR, msg st
 
 	reqCtx, cancel := context.WithTimeout(ctx, gl.timeout)
 	defer cancel()
-	opt := gitlab.CreateMergeRequestDiscussionOptions{Body: new(msg)}
+	opt := gitlab.CreateMergeRequestDiscussionOptions{Body: new(AddPintMarker(msg))}
 	_, _, err = gl.client.Discussions.CreateMergeRequestDiscussion(gl.project, mr.mrID, &opt, gitlab.WithContext(reqCtx))
 	return err
 }
@@ -376,6 +384,7 @@ func (gl GitLabReporter) noteToExisting(discID string, note *gitlab.Note) (c Exi
 	}
 	c.id = strconv.FormatInt(note.ID, 10)
 	c.text = note.Body
+	c.author = strconv.FormatInt(note.Author.ID, 10)
 	c.meta = gitlabComment{
 		discussionID: discID,
 		noteID:       note.ID,

--- a/internal/reporter/gitlab_test.go
+++ b/internal/reporter/gitlab_test.go
@@ -157,8 +157,8 @@ func TestGitLabReporter(t *testing.T) {
 		}
 		return path
 	}
-	discBody := func(reporter, summary, details string) *string {
-		return new(fmt.Sprintf(`:stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **%s** check.
+	discBody := func(check, summary, details string) *string {
+		return new(reporter.AddPintMarker(fmt.Sprintf(`:stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **%s** check.
 
 ------
 
@@ -172,10 +172,10 @@ func TestGitLabReporter(t *testing.T) {
 ------
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/%s.html).
-`, reporter, summary, details, reporter))
+`, check, summary, details, check)))
 	}
-	symlinkedDiscBody := func(reporter, summary, details, link string) *string {
-		return new(fmt.Sprintf(`:warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **%s** check.
+	symlinkedDiscBody := func(check, summary, details, link string) *string {
+		return new(reporter.AddPintMarker(fmt.Sprintf(`:warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **%s** check.
 
 ------
 
@@ -191,10 +191,10 @@ func TestGitLabReporter(t *testing.T) {
 ------
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/%s.html).
-`, reporter, summary, details, link, reporter))
+`, check, summary, details, link, check)))
 	}
-	discBodyWithDiag := func(reporter, summary, details, yml, diag string) *string {
-		return new(fmt.Sprintf(
+	discBodyWithDiag := func(check, summary, details, yml, diag string) *string {
+		return new(reporter.AddPintMarker(fmt.Sprintf(
 			`:stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **%s** check.
 
 <details>
@@ -211,8 +211,8 @@ func TestGitLabReporter(t *testing.T) {
 ------
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/a.html).
-`, reporter, summary, yml, diag, details,
-		))
+`, check, summary, yml, diag, details,
+		)))
 	}
 	discPosition := func(path string, line int64) *gitlab.PositionOptions {
 		return new(gitlab.PositionOptions{
@@ -382,9 +382,9 @@ func TestGitLabReporter(t *testing.T) {
 						s.ExpectGet(apiDiscussions(i, true)).ReturnJSON([]gitlab.Discussion{
 							{ID: "100", Notes: []*gitlab.Note{systemNote(discNote(101, 123, "system message", nil))}},
 							{ID: "200", Notes: []*gitlab.Note{discNote(201, 321, "different user", notePos("foo.txt", "foo.txt", 2, 0))}},
-							{ID: "300", Notes: []*gitlab.Note{discNote(301, 123, "stale comment", notePos("foo.txt", "foo.txt", 2, 0))}},
-							{ID: "400", Notes: []*gitlab.Note{discNote(401, 123, "stale comment on unmodified line", notePos("foo.txt", "foo.txt", 1, 0))}},
-							{ID: "500", Notes: []*gitlab.Note{discNote(101, 123, "no position", nil)}},
+							{ID: "300", Notes: []*gitlab.Note{discNote(301, 123, reporter.AddPintMarker("stale comment"), notePos("foo.txt", "foo.txt", 2, 0))}},
+							{ID: "400", Notes: []*gitlab.Note{discNote(401, 123, reporter.AddPintMarker("stale comment on unmodified line"), notePos("foo.txt", "foo.txt", 1, 0))}},
+							{ID: "500", Notes: []*gitlab.Note{discNote(101, 123, reporter.AddPintMarker("no position"), nil)}},
 						})
 					}
 
@@ -408,7 +408,7 @@ func TestGitLabReporter(t *testing.T) {
 				}
 
 				s.ExpectPost(apiDiscussions(5, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
-					Body:     new(":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **foo** check.\n\n------\n\nfoo error\n\n\u003cdetails\u003e\n\u003csummary\u003eMore information\u003c/summary\u003e\nfoo details\n\u003c/details\u003e\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).\n"),
+					Body:     new(reporter.AddPintMarker(":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **foo** check.\n\n------\n\nfoo error\n\n\u003cdetails\u003e\n\u003csummary\u003eMore information\u003c/summary\u003e\nfoo details\n\u003c/details\u003e\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/foo.html).\n")),
 					Position: discPosition("foo.txt", 2),
 				}).ReturnJSON(gitlab.Response{})
 			}),
@@ -476,7 +476,11 @@ func TestGitLabReporter(t *testing.T) {
 					},
 					{
 						ID:    "300",
-						Notes: []*gitlab.Note{resolvedNote(discNote(301, 123, "different line", notePos("foo.txt", "foo.txt", 1, 0)))},
+						Notes: []*gitlab.Note{resolvedNote(discNote(301, 123, reporter.AddPintMarker("different line"), notePos("foo.txt", "foo.txt", 1, 0)))},
+					},
+					{
+						ID:    "400",
+						Notes: []*gitlab.Note{discNote(401, 123, "comment without marker", notePos("foo.txt", "foo.txt", 2, 0))},
 					},
 				})
 				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
@@ -484,7 +488,7 @@ func TestGitLabReporter(t *testing.T) {
 					Position: discPosition("foo.txt", 1),
 				}).ReturnJSON(gitlab.Response{})
 				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
-					Body: new("This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR."),
+					Body: new(reporter.AddPintMarker("This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR.")),
 				}).ReturnJSON(gitlab.Response{})
 			}),
 			errorHandler: func(err error) error {
@@ -512,7 +516,7 @@ func TestGitLabReporter(t *testing.T) {
 					},
 					{
 						ID:    "200",
-						Notes: []*gitlab.Note{discNote(201, 123, "This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR.", nil)},
+						Notes: []*gitlab.Note{discNote(201, 123, reporter.AddPintMarker("This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR."), nil)},
 					},
 				})
 				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
@@ -584,7 +588,7 @@ func TestGitLabReporter(t *testing.T) {
 				})
 				s.ExpectGet(apiDiscussions(1, true)).ReturnJSON([]gitlab.Discussion{})
 				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
-					Body: new(`Some checks were disabled because one or more configured Prometheus server doesn't seem to support all required Prometheus APIs.
+					Body: new(reporter.AddPintMarker(`Some checks were disabled because one or more configured Prometheus server doesn't seem to support all required Prometheus APIs.
 This usually means that you're running pint against a service like Thanos or Mimir that allows to query metrics but doesn't implement all APIs documented [here](https://prometheus.io/docs/prometheus/latest/querying/api/).
 Since pint uses many of these API endpoint for querying information needed to run online checks only a real Prometheus server will allow it to run all of these checks.
 Below is the list of checks that were disabled for each Prometheus server defined in pint config file.
@@ -597,7 +601,7 @@ Below is the list of checks that were disabled for each Prometheus server define
 - ` + "`prom2`" + `
   - ` + "`/api/v1/metadata` " + `is unsupported, disabled checks:
     - [check1](https://cloudflare.github.io/pint/checks/check1.html)
-`),
+`)),
 				}).ReturnJSON(gitlab.Response{})
 			}),
 			errorHandler: func(err error) error {
@@ -655,7 +659,7 @@ Below is the list of checks that were disabled for each Prometheus server define
 					},
 					{
 						ID:    "300",
-						Notes: []*gitlab.Note{discNote(301, 123, "This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR.", nil)},
+						Notes: []*gitlab.Note{discNote(301, 123, reporter.AddPintMarker("This pint run would create 3 comment(s), which is more than the limit configured for pint (1).\n2 comment(s) were skipped and won't be visible on this PR."), nil)},
 					},
 				})
 				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
@@ -747,19 +751,19 @@ Below is the list of checks that were disabled for each Prometheus server define
 					{
 						ID: "200",
 						Notes: []*gitlab.Note{
-							discNote(201, 123, "different path", notePos("bar.txt", "bar.txt", 5, 0)),
+							discNote(201, 123, reporter.AddPintMarker("different path"), notePos("bar.txt", "bar.txt", 5, 0)),
 						},
 					},
 					{
 						ID: "300",
 						Notes: []*gitlab.Note{
-							discNote(301, 123, "different path", notePos("bar.txt", "", 1, 0)),
+							discNote(301, 123, reporter.AddPintMarker("different path"), notePos("bar.txt", "", 1, 0)),
 						},
 					},
 					{
 						ID: "400",
 						Notes: []*gitlab.Note{
-							discNote(401, 123, "different line", notePos("foo.txt", "", 0, 1)),
+							discNote(401, 123, reporter.AddPintMarker("different line"), notePos("foo.txt", "", 0, 1)),
 						},
 					},
 					{
@@ -1490,7 +1494,7 @@ func getHTTPHandlerForCommentingLines(expectedNewLine, expectedOldLine int, t *t
 				}
 
 				expected := `{
-		"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n\u003cdetails\u003e\n\u003csummary\u003eMore information\u003c/summary\u003e\nsyntax details\n\u003c/details\u003e\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n",
+		"body":":stop_sign: **Fatal** reported by [pint](https://cloudflare.github.io/pint/) **mock** check.\n\n------\n\nsyntax error\n\n\u003cdetails\u003e\n\u003csummary\u003eMore information\u003c/summary\u003e\nsyntax details\n\u003c/details\u003e\n\n------\n\n:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/mock.html).\n\n\u003c!-- pint --\u003e",
 		"position":{
 			"base_sha":"base",
 			"head_sha":"head",


### PR DESCRIPTION
We are running Pint alongside various other scripts/tools, such as promtool, mimirtool, and cortextool, since they all share the alerting pipelines for promql/logql. After `0.84.0` we noticed both user and other bot comments getting deleted.

```
level=INFO msg="Deleting stale general comment" reporter=GitHub id=5237764226
level=INFO msg="Deleting stale general comment" reporter=GitHub id=5237764454
```

We need to have some safeguards, so Pint detects its own comments.