### PR TITLE
Fix reports on symlinks

### DIFF
--- a/cmd/pint/tests/0276_ci_gitlab_added_symlink.txt
+++ b/cmd/pint/tests/0276_ci_gitlab_added_symlink.txt
@@ -1,0 +1,114 @@
+http method gitlab GET /api/v4/user 200 {"id": 555}
+http method gitlab GET /api/v4/projects/1234/merge_requests/1/versions 200 [{"id": 2, "head_commit_sha": "head", "base_commit_sha": "base", "start_commit_sha": "start"},{"id": 1, "head_commit_sha": "head", "base_commit_sha": "base", "start_commit_sha": "start"}]
+http method gitlab GET /api/v4/projects/1234/merge_requests/1/discussions 200 []
+http method gitlab GET /api/v4/projects/1234/merge_requests 200 [{"iid": 1}]
+http method gitlab POST /api/v4/projects/1234/merge_requests/1/discussions 200 {}
+http start gitlab 127.0.0.1:6276
+
+mkdir testrepo
+cd testrepo
+exec git init --initial-branch=main .
+
+cp ../src/rules.yml .
+cp ../src/.pint.hcl .
+env GIT_AUTHOR_NAME=pint
+env GIT_AUTHOR_EMAIL=pint@example.com
+env GIT_COMMITTER_NAME=pint
+env GIT_COMMITTER_EMAIL=pint@example.com
+exec git add .
+exec git commit -am 'import rules and config'
+
+exec git checkout -b v2
+# The branch adds a symlink to an unchanged rule file. GitLab must receive
+# the finding on the symlink line in the merge request diff.
+exec ln -s rules.yml symlink.yml
+exec git add symlink.yml
+exec git commit -m 'add rules symlink'
+
+env GITLAB_AUTH_TOKEN=secret
+exec pint -l debug --offline --no-color ci
+! stdout .
+cmp gitlab.got ../gitlab.expected
+
+-- src/rules.yml --
+groups:
+- name: foo
+  rules:
+  - alert: rule1
+    expr: sum(foo) by(job)
+
+-- src/.pint.hcl --
+ci {
+  baseBranch = "main"
+}
+repository {
+  gitlab {
+    uri        = "http://127.0.0.1:6276"
+    timeout    = "30s"
+    project    = "1234"
+  }
+}
+
+-- gitlab.expected --
+GET /api/v4/user
+  Accept: application/json
+  Accept-Encoding: gzip
+  Private-Token: secret
+
+GET /api/v4/projects/1234/merge_requests
+  Accept: application/json
+  Accept-Encoding: gzip
+  Private-Token: secret
+
+GET /api/v4/projects/1234/merge_requests/1/versions
+  Accept: application/json
+  Accept-Encoding: gzip
+  Private-Token: secret
+
+GET /api/v4/projects/1234/merge_requests/1/discussions
+  Accept: application/json
+  Accept-Encoding: gzip
+  Private-Token: secret
+
+POST /api/v4/projects/1234/merge_requests/1/discussions
+  Accept: application/json
+  Accept-Encoding: gzip
+  Content-Type: application/json
+  Private-Token: secret
+--- BODY ---
+body: |
+    :warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **alerts/comparison** check.
+
+    <details>
+    <summary>always firing alert</summary>
+
+    ```yaml
+    5 |     expr: sum(foo) by(job)
+                      ^^^
+    ```
+
+    This query doesn't have any condition and so this alert will always fire if it matches anything.
+
+    Prometheus alerting rules will trigger an alert for each query that returns *any* result.
+    Unless you do want an alert to always fire you should write your query in a way that returns results only when some condition is met.
+    In most cases this can be achieved by having some condition in the query expression.
+    For example `up == 0` or `rate(error_total[2m]) > 0`.
+    Be careful as some PromQL operations will cause the query to always return the results, for example using the [bool modifier](https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators).
+
+    </details>
+
+    :leftwards_arrow_with_hook: This problem was detected on a symlinked file `symlink.yml`.
+
+    ------
+
+    :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/alerts/comparison.html).
+position:
+    base_sha: base
+    head_sha: head
+    start_sha: start
+    new_path: symlink.yml
+    old_path: symlink.yml
+    position_type: text
+    new_line: 1
+--- END ---
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,11 @@
 - Duration expressions are now enabled by default as of Prometheus v3.14.0
   and no longer require `--enable-feature=promql-duration-expr`.
 
+### Fixed
+
+- GitHub, GitLab, and BitBucket reporters were trying to create comments on
+  incorrect lines for symlinked files.
+
 ## v0.87.0
 
 ### Added

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -84,6 +84,9 @@ type Changes struct {
 
 	// Modified lines.
 	Lines git.LineNumbers
+
+	// IsSymlink is true when the path after the change is a symlink.
+	IsSymlink bool
 }
 
 type Entry struct {

--- a/internal/discovery/git_branch.go
+++ b/internal/discovery/git_branch.go
@@ -73,7 +73,11 @@ func (f GitBranchFinder) Find(ctx context.Context, allEntries []*Entry) (entries
 
 		var fileChanges *Changes
 		if len(change.Body.Lines) > 0 || oldPath != "" {
-			fileChanges = &Changes{Lines: change.Body.Lines, OldPath: oldPath}
+			fileChanges = &Changes{
+				Lines:     change.Body.Lines,
+				OldPath:   oldPath,
+				IsSymlink: change.Path.After.Type == git.Symlink,
+			}
 		}
 
 		var entriesBefore, entriesAfter []*Entry

--- a/internal/discovery/git_branch_test.go
+++ b/internal/discovery/git_branch_test.go
@@ -456,7 +456,8 @@ groups:
 						SymlinkTarget: "rules.yml",
 					},
 					Changes: &discovery.Changes{
-						Lines: git.MakeLineRangeFromTo(1, 3, git.LinesAfter),
+						Lines:     git.MakeLineRangeFromTo(1, 3, git.LinesAfter),
+						IsSymlink: true,
 					},
 					Rule: mustParse(1, "- record: up:count\n  expr: count(up)\n"),
 				},

--- a/internal/reporter/comments.go
+++ b/internal/reporter/comments.go
@@ -175,6 +175,7 @@ func makeComments(summary Summary, showDuplicates bool) (comments []PendingComme
 		buf.WriteString(reports[0].Problem.Reporter)
 		buf.WriteString(".html).\n")
 
+		path := reports[0].Path.SymlinkTarget
 		line := reports[0].Problem.Lines.Last
 		oldPath := ""
 		changedLines := git.LineNumbers{}
@@ -187,10 +188,14 @@ func makeComments(summary Summary, showDuplicates bool) (comments []PendingComme
 					break
 				}
 			}
+			if reports[0].Changes.IsSymlink {
+				path = reports[0].Path.Name
+				line = 1
+			}
 		}
 
 		pc := PendingComment{
-			path:       reports[0].Path.SymlinkTarget,
+			path:       path,
 			oldPath:    oldPath,
 			text:       buf.String(),
 			line:       line,

--- a/internal/reporter/gitlab_test.go
+++ b/internal/reporter/gitlab_test.go
@@ -56,6 +56,8 @@ func TestGitLabReporter(t *testing.T) {
 	tmpDir := t.TempDir()
 	mockPath := filepath.Join(tmpDir, "foo.txt")
 	require.NoError(t, os.WriteFile(mockPath, []byte(mockRules), 0o644))
+	mockLink := filepath.Join(tmpDir, "link.txt")
+	require.NoError(t, os.Symlink(mockPath, mockLink))
 	mockFile := p.Parse(strings.NewReader(mockRules))
 
 	fooReport := reporter.Report{
@@ -171,6 +173,25 @@ func TestGitLabReporter(t *testing.T) {
 
 :information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/%s.html).
 `, reporter, summary, details, reporter))
+	}
+	symlinkedDiscBody := func(reporter, summary, details, link string) *string {
+		return new(fmt.Sprintf(`:warning: **Warning** reported by [pint](https://cloudflare.github.io/pint/) **%s** check.
+
+------
+
+%s
+
+<details>
+<summary>More information</summary>
+%s
+</details>
+
+:leftwards_arrow_with_hook: This problem was detected on a symlinked file `+"`%s`"+`.
+
+------
+
+:information_source: To see documentation covering this check and instructions on how to resolve it [click here](https://cloudflare.github.io/pint/checks/%s.html).
+`, reporter, summary, details, link, reporter))
 	}
 	discBodyWithDiag := func(reporter, summary, details, yml, diag string) *string {
 		return new(fmt.Sprintf(
@@ -1168,6 +1189,59 @@ Below is the list of checks that were disabled for each Prometheus server define
 				s.ExpectGet(apiDiscussions(1, true)).ReturnJSON([]gitlab.Discussion{})
 				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
 					Body: discBody("a", "foo error1", "foo details"),
+				}).ReturnJSON(gitlab.Response{})
+			}),
+			errorHandler: func(err error) error {
+				return err
+			},
+		},
+		{
+			description: "symlink target outside diff",
+			timeout:     time.Minute,
+			maxComments: 1,
+			// The merge request adds mockLink, while the problem belongs to
+			// mockPath, which is not in the merge request diff.
+			summary: reporter.NewSummary([]reporter.Report{
+				{
+					Path: discovery.Path{
+						Name:          mockLink,
+						SymlinkTarget: mockPath,
+					},
+					Changes: &discovery.Changes{
+						OldPath:   "",
+						Lines:     git.MakeLineRangeFromTo(1, 4, git.LinesAfter),
+						IsSymlink: true,
+					},
+					Rule: mockFile.Groups[0].Rules[1],
+					Problem: checks.Problem{
+						Reporter:    "foo",
+						Summary:     "foo error",
+						Details:     "foo details",
+						Diagnostics: []diags.Diagnostic{},
+						Lines:       diags.LineRange{First: 4, Last: 4},
+						Severity:    checks.Warning,
+						Anchor:      checks.AnchorAfter,
+					},
+				},
+			}),
+			mock: httpmock.New(func(s *httpmock.Server) {
+				s.ExpectGet(apiUser).ReturnJSON(gitlab.User{ID: 123})
+				s.ExpectGet(apiOpenMergeRequests).ReturnJSON([]gitlab.BasicMergeRequest{
+					{IID: 1},
+				})
+				s.ExpectGet(apiVersions(1)).ReturnJSON([]gitlab.MergeRequestDiffVersion{
+					{ID: 2, HeadCommitSHA: "head", BaseCommitSHA: "base", StartCommitSHA: "start"},
+					{ID: 1, HeadCommitSHA: "head", BaseCommitSHA: "base", StartCommitSHA: "start"},
+				})
+				s.ExpectGet(apiDiscussions(1, true)).ReturnJSON([]gitlab.Discussion{})
+				s.ExpectPost(apiDiscussions(1, false)).WithBodyJSON(gitlab.CreateMergeRequestDiscussionOptions{
+					Body: symlinkedDiscBody(
+						"foo",
+						"foo error",
+						"foo details",
+						mockLink,
+					),
+					Position: discPosition(mockLink, 1),
 				}).ReturnJSON(gitlab.Response{})
 			}),
 			errorHandler: func(err error) error {


### PR DESCRIPTION
When user adds a symlink that points to a file that's not in the diff then we might end up reporting issues on the file outside of the diff.